### PR TITLE
Add support for GPOS kerning information parsing

### DIFF
--- a/bin/ot
+++ b/bin/ot
@@ -7,7 +7,8 @@ var opentype = require('../opentype.js');
 // Print out information about the font on the console.
 function printFontInfo(font) {
     console.log('  glyphs:', font.glyphs.length);
-    console.log('  kerning pairs:', Object.keys(font.kerningPairs).length);
+    console.log('  kerning pairs (kern table):', Object.keys(font.kerningPairs).length);
+    console.log('  kerning pairs (GPOS table):', (font.getGposKerningValue) ? 'yes' : 'no');
 }
 
 // Recursively walk a directory and execute the function for every file.


### PR DESCRIPTION
This PR provides basic GPOS table parsing.
It reads Pair Adjustment Positioning Subtables (format 1 and 2).
It does not use script and feature information, nor vertical adjustment information.
