### PR TITLE
fix for Safari 7

### DIFF
--- a/opentype.js
+++ b/opentype.js
@@ -208,7 +208,7 @@
     // The data can be either a DataView or an array of bytes.
     function Parser(data, offset) {
         this.data = data;
-        this.isDataView = data instanceof DataView;
+        this.isDataView = typeof DataView !== 'undefined' && data instanceof DataView;
         this.offset = offset;
         this.relativeOffset = 0;
     }


### PR DESCRIPTION
I don't know why the type was detected that way, but in safari 7.0.2 (9537.74.9)  data.constructor.name is undefined.
