### PR TITLE
Fix cmap wrong idRangeOffset

### DIFF
--- a/opentype.js
+++ b/opentype.js
@@ -1179,7 +1179,6 @@
         cmap.format = format = p.parseUShort();
         checkArgument(format === 4, 'Only format 4 cmap tables are supported.');
         // Length in bytes of the sub-tables.
-        // Skip length and language;
         cmap.length = p.parseUShort();
         cmap.language = p.parseUShort();
         // segCount is stored x 2.


### PR DESCRIPTION
Fixes an issue with possibly malformed cmap tables. Loading e.g. the [TrashHand](http://www.dafont.com/fr/trash-hand.font) font leads to a "RangeError: argument 1 accesses an index that is out of range".

This issue has already been dealt with in the FreeType library :
http://marc.info/?l=freetype&m=91764687315696&w=2
