### PR TITLE
Use the defaultWidthX, not the nominalWidthX

### DIFF
--- a/src/tables/cff.js
+++ b/src/tables/cff.js
@@ -314,7 +314,7 @@ function parseCFFCharstring(code, font, index) {
     stack = [];
     nStems = 0;
     haveWidth = false;
-    width = font.nominalWidthX;
+    width = font.defaultWidthX;
     x = y = 0;
 
     function parseStems() {


### PR DESCRIPTION
This fixes a bug with [Dosis Regular](http://www.fontsquirrel.com/fonts/dosis), in particular the `i` characters.
