### PR TITLE
encode.CHARSTRING is often used on the exact same objects

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -3,7 +3,6 @@
 
 'use strict';
 
-var polyfill = require('../node_modules/es6-collections');
 var check = require('./check');
 
 var LIMIT16 = 32768; // The limit at which a 16-bit number switches signs == 2^15


### PR DESCRIPTION
Hi Frederik,

We're started to play around with opentype.js and see how we can use it in Prototypo!
First things first : I played with editor.html and opened a profiler. I noticed that the encoder was spending most of its time inside encode.CHARSTRING, and that it was often used on the exact same objects, producing the same result.
This patch is just a quick work-around to this problem but yields x2 speedup, according to my tests. Since you have a better knowledge of the code, you might be able to come up with a better solution.

I've also started to remove `.length` lookups from `for` loops declaration, as this is a clear, simple and effective perf optimization.

This bug is mostly here to get the discussion started.
Also: how can we start instrumenting and monitoring perf profiling?
