### PR TITLE
direct npm main to dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "type": "git",
     "url": "git://github.com/nodebox/opentype.js.git"
   },
-  "main": "opentype.js",
+  "main": "dist/opentype.js",
   "bin": {
     "ot": "./bin/ot"
   },


### PR DESCRIPTION
require('opentype.js') fails on node.js - 'main' should direct to dist folder.
