### PR TITLE
Fixed inconsistent return value when kerning value is not found

### DIFF
--- a/src/tables/gpos.js
+++ b/src/tables/gpos.js
@@ -164,11 +164,14 @@ function parsePairPosSubTable(data, start) {
 
         // Get the kerning value for a specific glyph pair.
         return function(leftGlyph, rightGlyph) {
-            if (!covered[leftGlyph]) return null;
+            if (!covered[leftGlyph]) return;
             var class1 = getClass1(leftGlyph),
                 class2 = getClass2(rightGlyph),
                 kerningRow = kerningMatrix[class1];
-            return kerningRow ? kerningRow[class2] : null;
+                
+            if (kerningRow) {
+                return kerningRow[class2];
+            }
         };
     }
 }


### PR DESCRIPTION
On line #203 the returned value is checked against "undefined" to short out, yet the subtable function can return "null", which leads to incorrect value of "null" being returned too early in table.getKerningValue
