### PR TITLE
Adds support for browser Async/Await for .load()

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ opentype.load('fonts/Roboto-Black.ttf', function(err, font) {
 });
 ```
 
+You can also use `es6 async/await` syntax to load your fonts
+
+```javascript
+async function make(){
+    const font = await opentype.load('fonts/Roboto-Black.ttf');
+    const path = font.getPath('Hello, World!', 0, 150, 72);
+    console.log(path);
+}
+```
+
 If you already have an `ArrayBuffer`, you can use `opentype.parse(buffer)` to parse the buffer. This method always
 returns a Font, but check `font.supported` to see if the font is in a supported format. (Fonts can be marked unsupported
 if they have encoding tables we can't read).

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -375,7 +375,7 @@ function load(url, callback, opt) {
     const isNode = typeof window === 'undefined';
     const loadFn = isNode ? loadFromFile : loadFromUrl;
 
-    if (callback) {
+    return new Promise((resolve) => {
         loadFn(url, function(err, arrayBuffer) {
             if (err) {
                 return callback(err);
@@ -386,24 +386,13 @@ function load(url, callback, opt) {
             } catch (e) {
                 return callback(e, null);
             }
-            return callback(null, font);
-        });
-    } else {
-        return new Promise((resolve, reject) => {
-            loadFn(url, (err, arrayBuffer) => {
-                if (err) {
-                    reject(err);
-                }
-                let font;
-                try {
-                    font = parseBuffer(arrayBuffer, opt);
-                } catch (e) {
-                    reject(e);
-                }
+            if (callback) {
+                return callback(null, font);
+            } else {
                 resolve(font);
-            });
+            }
         });
-    }
+    });
 }
 
 /**

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -375,7 +375,7 @@ function load(url, callback, opt) {
     const isNode = typeof window === 'undefined';
     const loadFn = isNode ? loadFromFile : loadFromUrl;
 
-    if(callback){
+    if (callback) {
         loadFn(url, function(err, arrayBuffer) {
             if (err) {
                 return callback(err);
@@ -389,7 +389,7 @@ function load(url, callback, opt) {
             return callback(null, font);
         });
     } else {
-        return new Promise( (resolve, reject) => {
+        return new Promise((resolve, reject) => {
             loadFn(url, (err, arrayBuffer) => {
                 if (err) {
                     reject(err);
@@ -401,10 +401,9 @@ function load(url, callback, opt) {
                     reject(e);
                 }
                 resolve(font);
-            })
-        })
+            });
+        });
     }
-    
 }
 
 /**

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -374,18 +374,37 @@ function parseBuffer(buffer, opt) {
 function load(url, callback, opt) {
     const isNode = typeof window === 'undefined';
     const loadFn = isNode ? loadFromFile : loadFromUrl;
-    loadFn(url, function(err, arrayBuffer) {
-        if (err) {
-            return callback(err);
-        }
-        let font;
-        try {
-            font = parseBuffer(arrayBuffer, opt);
-        } catch (e) {
-            return callback(e, null);
-        }
-        return callback(null, font);
-    });
+
+    if(callback){
+        loadFn(url, function(err, arrayBuffer) {
+            if (err) {
+                return callback(err);
+            }
+            let font;
+            try {
+                font = parseBuffer(arrayBuffer, opt);
+            } catch (e) {
+                return callback(e, null);
+            }
+            return callback(null, font);
+        });
+    } else {
+        return new Promise( (resolve, reject) => {
+            loadFn(url, (err, arrayBuffer) => {
+                if (err) {
+                    reject(err);
+                }
+                let font;
+                try {
+                    font = parseBuffer(arrayBuffer, opt);
+                } catch (e) {
+                    reject(e);
+                }
+                resolve(font);
+            })
+        })
+    }
+    
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Hello + Thank you for your wonderful work with Opentype. It's a wonderful library.

Feel free to reach out with any questions or comments. 

## Description
<!--- Describe your changes in detail -->

Adds a small conditional to the `.load()` function to support and `promises` and `async/await` for loading font files in the browser. 

Usage looks like:

For promises:
```js
opentype.load('fonts/my-wonderful-font.otf').then( font => {
   console.log(font)
});
```

For async/await:
```js
async function make() {
	try {
		const font = await opentype.load('fonts/PublicSans-Regular.otf');
		console.log(font)
	} catch (err) {
		console.log(err);
	}
}
make();
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change can make help resolve visual callback craziness and may enhance user experience. Also it may be nice as a way of cleaning up code for teaching and workshops. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Tested in Firefox and Chrome

Same behavior with callbacks:
See: https://github.com/joeyklee/sandbox/tree/master/opentype-examples/load-callbacks
Demo: https://joeyklee.github.io/sandbox/opentype-examples/load-callbacks/

Demo using async/await:
See: https://github.com/joeyklee/sandbox/tree/master/opentype-examples/load-promise
Demo: https://joeyklee.github.io/sandbox/opentype-examples/load-promise/


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [X] I have added tests to cover my changes. ==> see examples above
- [X] My change requires a change to the documentation. ==>  Maybe? 
- [X] I have updated the **README** accordingly.
- [X] I have read the **CONTRIBUTING** document.
