### PR TITLE
Introduce ES6 module build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "git://github.com/opentypejs/opentype.js.git"
   },
   "main": "dist/opentype.js",
-  "module": "src/opentype.js",
+  "module": "dist/opentype.module.js",
   "bin": {
     "ot": "./bin/ot"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,12 +5,19 @@ var license = require('rollup-plugin-license');
 
 module.exports = {
     input: 'src/opentype.js',
-    output: {
-        file: 'dist/opentype.js',
-        format: 'umd',
-        name: 'opentype',
-        sourcemap: true
-    },
+    output: [
+        {
+            file: 'dist/opentype.js',
+            format: 'umd',
+            name: 'opentype',
+            sourcemap: true
+        },
+        {
+            file: 'dist/opentype.module.js',
+            format: 'es',
+            sourcemap: true
+        }
+   ],
     plugins: [
         resolve({
             jsnext: true,


### PR DESCRIPTION
This PR introduces `opentype.module.js`, a single build file representing the lib as a ES6 module.

## Description

The new dist file is configured in `rollup.config.js`. Besides, the `module` property of `package.json` now points to it (and not the `src/opentype.js` anymore).

## Motivation and Context

We the `three.js` team currently convert our example codebase to ES6 modules. We also use `opentype.js` in one of our [loaders](https://threejs.org/examples/webgl_loader_ttf). However, it still depends on the `opentype.js` UMD version. Since we copy build files to our example directory, it's not possible to use `npm` and the exports from [src/opentype.js](https://github.com/opentypejs/opentype.js/blob/master/src/opentype.js).

## How Has This Been Tested?

I've tested the new build file with `THREE.TTFLoader` and the respective example. 

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.  (not sure)
- [ ] I have updated the **README** accordingly. (not sure)
- [x] I have read the **CONTRIBUTING** document.