### PR TITLE
Remove Node 4 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- '4'  # https://github.com/opentypejs/opentype.js/pull/251#issuecomment-272175882
 - '10'
 deploy:
   provider: npm


### PR DESCRIPTION
I just updated the dev dependencies and they won't work with Node 4 anymore.

So I'm removing it from Travis and Node 10 will be the only version tested from now.

Let me know if you see any issue with that ;-)