### PR TITLE
Write OS/2 Table with sxHeight & sCapHeight

### DIFF
--- a/src/tables/sfnt.js
+++ b/src/tables/sfnt.js
@@ -241,12 +241,12 @@ function fontToSfntTable(font) {
         // ordering was chosen experimentally.
         sTypoAscender: globals.ascender,
         sTypoDescender: globals.descender,
-        sTypoLineGap: 0,
+        sTypoLineGap: font.tables.os2.sTypoLineGap || 0,
         usWinAscent: globals.yMax,
         usWinDescent: Math.abs(globals.yMin),
         ulCodePageRange1: 1, // FIXME: hard-code Latin 1 support for now
-        sxHeight: metricsForChar(font, 'xyvw', {yMax: Math.round(globals.ascender / 2)}).yMax,
-        sCapHeight: metricsForChar(font, 'HIKLEFJMNTZBDPRAGOQSUVWXY', globals).yMax,
+        sxHeight: font.tables.os2.sxHeight || metricsForChar(font, 'xyvw', {yMax: Math.round(globals.ascender / 2)}).yMax,
+        sCapHeight: font.tables.os2.sCapHeight || metricsForChar(font, 'HIKLEFJMNTZBDPRAGOQSUVWXY', globals).yMax,
         usDefaultChar: font.hasChar(' ') ? 32 : 0, // Use space as the default character, if available.
         usBreakChar: font.hasChar(' ') ? 32 : 0 // Use space as the break character, if available.
     });


### PR DESCRIPTION
If the library is needed to write just small fonts in a programmatically way it can be useful to have more control over the OS/2 Table. This PR gives the option to set `sTypoLineGap`, `sxHeight` and `sCapHeight` for the Font-Generation. It's optional and existing code will not break. (SemVer: Minor). In theory it would be useful to have all values under control. But this was just my usecase and I also tested it. See: https://github.com/opentypejs/opentype.js/issues/409

## use
```js
var test = new Font({
  familyName: "TestFont",
  styleName: "Bold",
  unitsPerEm: 2048,
  ascender: 1500,
  descender: -500,
  glyphs: [
    new Glyph({
      name: ".notdef",
      advanceWidth: 650,
      path: new Path()
    })
  ]
});

test.tables.os2 = {
  ...test.tables.os2,
  sxHeight: 1100,
  sCapHeight: 1400,
  sTypoLineGap: 150
};
test.download();
```