### PR TITLE
Fix use of Promise / async/await in the load function

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -375,16 +375,24 @@ function load(url, callback, opt) {
     const isNode = typeof window === 'undefined';
     const loadFn = isNode ? loadFromFile : loadFromUrl;
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         loadFn(url, function(err, arrayBuffer) {
             if (err) {
-                return callback(err);
+                if (callback) {
+                    return callback(err);
+                } else {
+                    reject(err);
+                }
             }
             let font;
             try {
                 font = parseBuffer(arrayBuffer, opt);
             } catch (e) {
-                return callback(e, null);
+                if (callback) {
+                    return callback(e, null);
+                } else {
+                    reject(e);
+                }
             }
             if (callback) {
                 return callback(null, font);

--- a/test/opentypeSpec.js
+++ b/test/opentypeSpec.js
@@ -12,6 +12,18 @@ describe('opentype.js', function() {
         assert.equal(aGlyph.path.commands.length, 15);
     });
 
+    it('can load a TrueType font as a resolved promise', function(done) {
+        load('./fonts/Roboto-Black.ttf').then((font) => {
+            assert.deepEqual(font.names.fontFamily, {en: 'Roboto Black'});
+            assert.equal(font.unitsPerEm, 2048);
+            assert.equal(font.glyphs.length, 1294);
+            const aGlyph = font.charToGlyph('A');
+            assert.equal(aGlyph.unicode, 65);
+            assert.equal(aGlyph.path.commands.length, 15);
+            done();
+        });
+    });
+
     it('can load a OpenType/CFF font', function() {
         const font = loadSync('./fonts/FiraSansOT-Medium.otf');
         assert.deepEqual(font.names.fontFamily, {en: 'Fira Sans OT Medium'});
@@ -56,6 +68,15 @@ describe('opentype.js', function() {
                 done();
             }
         });
+    });
+
+    it('handles a parseBuffer error as a rejected promise', function(done) {
+        load('./fonts/badfont.ttf')
+            .catch((err) => {
+                if (err) {
+                    done();
+                }
+            });
     });
 
     it('throws an error when advanceWidth is not set', function() {


### PR DESCRIPTION
## Description
Fixes the incomplete Promise / async/await support for the load function – the initial implementation did not support using `reject` for problem paths and always attempted to use the potentially null `callback` instead.

## Motivation and Context
Fixes #406

## How Has This Been Tested?
Additional unit tests to cover existing feature and prove bug existence & resolution.

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
