### PR TITLE
Unify internal Glyph.unicode{,s} usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ aPath.lineTo(100, 700);
 // more drawing instructions...
 const aGlyph = new opentype.Glyph({
     name: 'A',
-    unicode: 65,
+    unicodes: [65],
     advanceWidth: 650,
     path: aPath
 });

--- a/examples/creating-fonts.html
+++ b/examples/creating-fonts.html
@@ -101,7 +101,7 @@
     aPath.lineTo(200, 600);
     var aGlyph = new opentype.Glyph({
         name: 'A',
-        unicode: 65,
+        unicodes: [65],
         advanceWidth: 650,
         path: aPath
     });
@@ -123,7 +123,7 @@
     bPath.lineTo(200, 300);
     var bGlyph = new opentype.Glyph({
         name: 'B',
-        unicode: 66,
+        unicodes: [66],
         advanceWidth: 650,
         path: bPath
     });

--- a/examples/font-editor.html
+++ b/examples/font-editor.html
@@ -448,7 +448,7 @@
             }));
             otGlyphs.push(new opentype.Glyph({
                 name: 'space',
-                unicode: 32,
+                unicodes: [32],
                 path: new opentype.Path(),
                 advanceWidth: 7 * TTF_SCALE
             }));
@@ -473,7 +473,7 @@
                 }
                 var newGlyph = new opentype.Glyph({
                     name: ttfName,
-                    unicode: c.charCodeAt(0),
+                    unicodes: [c.charCodeAt(0)],
                     advanceWidth: (w + 1) * TTF_SCALE,
                     path: p
                 });

--- a/examples/generate-font-node.js
+++ b/examples/generate-font-node.js
@@ -91,7 +91,7 @@ var notdefGlyph = new Glyph({
 // Our glyph map can't properly encode a space character, so we make one here.
 var spaceGlyph = new Glyph({
     name: 'space',
-    unicode: 32,
+    unicodes: [32],
     advanceWidth: 10 * SCALE,
     path: new Path()
 });
@@ -124,7 +124,7 @@ for (var i = 0; i < glyphNames.length; i++) {
     // Create the glyph. The advanceWidth is the widest part of the letter + 1.
     var glyph = new Glyph({
         name: ttfName,
-        unicode: glyphName.charCodeAt(0),
+        unicodes: [glyphName.charCodeAt(0)],
         advanceWidth: (w + 1) * SCALE,
         path: path
     });

--- a/examples/reading-writing.html
+++ b/examples/reading-writing.html
@@ -50,7 +50,7 @@
     function createGlyphCanvas(glyph, size) {
         var canvasId, html, glyphsDiv, wrap, canvas, ctx;
         canvasId = 'c' + glyph.index;
-        html = '<div class="wrapper" style="width:' + size + 'px"><canvas id="' + canvasId + '" width="' + size + '" height="' + size + '"></canvas><span>' + glyph.index + '</span><span>' + glyph.name + '</span><span>U ' + glyph.unicode + '</span></div>';
+        html = '<div class="wrapper" style="width:' + size + 'px"><canvas id="' + canvasId + '" width="' + size + '" height="' + size + '"></canvas><span>' + glyph.index + '</span><span>' + glyph.name + '</span><span>U ' + glyph.unicodes.join() + '</span></div>';
         glyphsDiv = document.getElementById('glyphs');
         wrap = document.createElement('div');
         wrap.innerHTML = html;

--- a/glyph-inspector.html
+++ b/glyph-inspector.html
@@ -133,7 +133,7 @@ function displayGlyphData(glyphIndex) {
     html += '<dt>name</dt><dd>'+glyph.name+'</dd>';
 
     if (glyph.unicodes.length > 0) {
-        html += '<dt>unicode</dt><dd>'+ glyph.unicodes.map(formatUnicode).join(', ') +'</dd>';
+        html += '<dt>unicodes</dt><dd>'+ glyph.unicodes.map(formatUnicode).join(', ') +'</dd>';
     }
     html += '<dt>index</dt><dd>'+glyph.index+'</dd>';
 

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -61,9 +61,11 @@ Glyph.prototype.bindConstructorValues = function(options) {
 
     // These three values cannot be deferred for memory optimization:
     this.name = options.name || null;
-    this.unicode = options.unicode || undefined;
-    this.unicodes = options.unicodes || options.unicode !== undefined ? [options.unicode] : [];
-
+    this.unicodes = options.unicodes || [];
+    if ('unicode' in options) {
+        this.unicodes.push(options.unicode);
+    }
+    
     // But by binding these values only when necessary, we reduce can
     // the memory requirements by almost 3% for larger fonts.
     if ('xMin' in options) {
@@ -96,10 +98,6 @@ Glyph.prototype.bindConstructorValues = function(options) {
  * @param {number}
  */
 Glyph.prototype.addUnicode = function(unicode) {
-    if (this.unicodes.length === 0) {
-        this.unicode = unicode;
-    }
-
     this.unicodes.push(unicode);
 };
 

--- a/src/tables/cmap.js
+++ b/src/tables/cmap.js
@@ -147,7 +147,7 @@ function makeCmapTable(glyphs) {
     // Check if we need to add cmap format 12 or if format 4 only is fine
     for (i = glyphs.length - 1; i > 0; i -= 1) {
         const g = glyphs.get(i);
-        if (g.unicode > 65535) {
+        if (g.unicodes.some(v => v > 65535)) {
             console.log('Adding CMAP format 12 (needed!)');
             isPlan0Only = false;
             break;

--- a/test/font.js
+++ b/test/font.js
@@ -4,11 +4,11 @@ import { Font, Glyph, Path, loadSync } from '../src/opentype';
 describe('font.js', function() {
     let font;
 
-    const fGlyph = new Glyph({name: 'f', unicode: 102, path: new Path(), advanceWidth: 1});
-    const iGlyph = new Glyph({name: 'i', unicode: 105, path: new Path(), advanceWidth: 1});
-    const ffGlyph = new Glyph({name: 'f_f', unicode: 0xfb01, path: new Path(), advanceWidth: 1});
-    const fiGlyph = new Glyph({name: 'f_i', unicode: 0xfb02, path: new Path(), advanceWidth: 1});
-    const ffiGlyph = new Glyph({name: 'f_f_i', unicode: 0xfb03, path: new Path(), advanceWidth: 1});
+    const fGlyph = new Glyph({name: 'f', unicodes: [102], path: new Path(), advanceWidth: 1});
+    const iGlyph = new Glyph({name: 'i', unicodes: [105], path: new Path(), advanceWidth: 1});
+    const ffGlyph = new Glyph({name: 'f_f', unicodes: [0xfb01], path: new Path(), advanceWidth: 1});
+    const fiGlyph = new Glyph({name: 'f_i', unicodes: [0xfb02], path: new Path(), advanceWidth: 1});
+    const ffiGlyph = new Glyph({name: 'f_f_i', unicodes: [0xfb03], path: new Path(), advanceWidth: 1});
 
     const glyphs = [
         new Glyph({name: '.notdef', unicode: 0, path: new Path(), advanceWidth: 1}),

--- a/test/layout.js
+++ b/test/layout.js
@@ -20,7 +20,7 @@ describe('layout.js', function() {
     const glyphs = [notdefGlyph].concat('abcdefghijklmnopqrstuvwxyz'.split('').map(function (c) {
         return new Glyph({
             name: c,
-            unicode: c.charCodeAt(0),
+            unicodes: [c.charCodeAt(0)],
             path: new Path()
         });
     }));

--- a/test/opentypeSpec.js
+++ b/test/opentypeSpec.js
@@ -8,7 +8,7 @@ describe('opentype.js', function() {
         assert.equal(font.unitsPerEm, 2048);
         assert.equal(font.glyphs.length, 1294);
         const aGlyph = font.charToGlyph('A');
-        assert.equal(aGlyph.unicode, 65);
+        assert.deepEqual(aGlyph.unicodes, [65]);
         assert.equal(aGlyph.path.commands.length, 15);
     });
 
@@ -18,7 +18,7 @@ describe('opentype.js', function() {
             assert.equal(font.unitsPerEm, 2048);
             assert.equal(font.glyphs.length, 1294);
             const aGlyph = font.charToGlyph('A');
-            assert.equal(aGlyph.unicode, 65);
+            assert.deepEqual(aGlyph.unicodes, [65]);
             assert.equal(aGlyph.path.commands.length, 15);
             done();
         });
@@ -31,7 +31,7 @@ describe('opentype.js', function() {
         assert.equal(font.glyphs.length, 1151);
         const aGlyph = font.charToGlyph('A');
         assert.equal(aGlyph.name, 'A');
-        assert.equal(aGlyph.unicode, 65);
+        assert.deepEqual(aGlyph.unicodes, [65]);
         assert.equal(aGlyph.path.commands.length, 14);
     });
 
@@ -47,7 +47,7 @@ describe('opentype.js', function() {
         assert.equal(font.glyphs.length, 257);
         const aGlyph = font.glyphs.get(2);
         assert.equal(aGlyph.name, 'gid2');
-        assert.equal(aGlyph.unicode, 1);
+        assert.equal(aGlyph.unicodes.length, 4344);
         assert.equal(aGlyph.path.commands.length, 24);
     });
 
@@ -58,7 +58,7 @@ describe('opentype.js', function() {
         assert.equal(font.glyphs.length, 1147);
         const aGlyph = font.charToGlyph('A');
         assert.equal(aGlyph.name, 'A');
-        assert.equal(aGlyph.unicode, 65);
+        assert.deepEqual(aGlyph.unicodes, [65]);
         assert.equal(aGlyph.path.commands.length, 14);
     });
 
@@ -106,7 +106,7 @@ describe('opentype.js on low memory mode', function() {
         assert.equal(font.unitsPerEm, 2048);
         assert.equal(font.glyphs.length, 0);
         const aGlyph = font.charToGlyph('A');
-        assert.equal(aGlyph.unicode, 65);
+        assert.deepEqual(aGlyph.unicodes, [65]);
         assert.equal(aGlyph.path.commands.length, 15);
     });
 
@@ -117,7 +117,7 @@ describe('opentype.js on low memory mode', function() {
         assert.equal(font.glyphs.length, 0);
         const aGlyph = font.charToGlyph('A');
         assert.equal(aGlyph.name, 'A');
-        assert.equal(aGlyph.unicode, 65);
+        assert.deepEqual(aGlyph.unicodes, [65]);
         assert.equal(aGlyph.path.commands.length, 14);
     });
 
@@ -133,7 +133,7 @@ describe('opentype.js on low memory mode', function() {
         assert.equal(font.glyphs.length, 0);
         const aGlyph = font.glyphs.get(2);
         assert.equal(aGlyph.name, 'gid2');
-        assert.equal(aGlyph.unicode, 1);
+        assert.equal(aGlyph.unicodes.length, 4344);
         assert.equal(aGlyph.path.commands.length, 24);
     });
 
@@ -144,7 +144,7 @@ describe('opentype.js on low memory mode', function() {
         assert.equal(font.glyphs.length, 0);
         const aGlyph = font.charToGlyph('A');
         assert.equal(aGlyph.name, 'A');
-        assert.equal(aGlyph.unicode, 65);
+        assert.deepEqual(aGlyph.unicodes, [65]);
         assert.equal(aGlyph.path.commands.length, 14);
     });
 

--- a/test/substitution.js
+++ b/test/substitution.js
@@ -14,7 +14,7 @@ describe('substitution.js', function() {
     const glyphs = [notdefGlyph].concat('abcdefghijklmnopqrstuvwxyz'.split('').map(function (c) {
         return new Glyph({
             name: c,
-            unicode: c.charCodeAt(0),
+            unicodes: [c.charCodeAt(0)],
             path: new Path()
         });
     }));


### PR DESCRIPTION
## Description
This commit:
- centralize this data into a the `unicodes` attribute.
- keep the Glyph API for specifying a single `unicode` value.
- update the documentation with both properties examples
- update the tests


## Motivation and Context
Both Glyph.unicode and Glyph.unicodes were used to store the glyph
unicodes values. This duplication led to some bugs when handling the
glyph unicodes.

## How Has This Been Tested?
I re-run the testcases and updates some that where kind of useless lick checking the first unicode of a glyph that match 4000 unicodes (`./node_modules/.bin/mocha --require reify --recursive --bail -g CID`)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
