### PR TITLE
Add support for parsing GDEF table

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -18,6 +18,7 @@ import cmap from './tables/cmap';
 import cff from './tables/cff';
 import fvar from './tables/fvar';
 import glyf from './tables/glyf';
+import gdef from './tables/gdef';
 import gpos from './tables/gpos';
 import gsub from './tables/gsub';
 import head from './tables/head';
@@ -211,6 +212,7 @@ function parseBuffer(buffer, opt) {
     let cffTableEntry;
     let fvarTableEntry;
     let glyfTableEntry;
+    let gdefTableEntry;
     let gposTableEntry;
     let gsubTableEntry;
     let hmtxTableEntry;
@@ -296,6 +298,9 @@ function parseBuffer(buffer, opt) {
             case 'kern':
                 kernTableEntry = tableEntry;
                 break;
+            case 'GDEF':
+                gdefTableEntry = tableEntry;
+                break;
             case 'GPOS':
                 gposTableEntry = tableEntry;
                 break;
@@ -334,6 +339,11 @@ function parseBuffer(buffer, opt) {
         font.kerningPairs = kern.parse(kernTable.data, kernTable.offset);
     } else {
         font.kerningPairs = {};
+    }
+
+    if (gdefTableEntry) {
+        const gdefTable = uncompressTable(data, gdefTableEntry);
+        font.tables.gdef = gdef.parse(gdefTable.data, gdefTable.offset);
     }
 
     if (gposTableEntry) {

--- a/src/tables/gdef.js
+++ b/src/tables/gdef.js
@@ -3,50 +3,49 @@
 
 import check from '../check';
 import { Parser } from '../parse';
-import table from '../table';
 
 var attachList = function() {
     return {
         coverage: this.parsePointer(Parser.coverage),
         attachPoints: this.parseList(Parser.pointer(Parser.uShortList))
-    }
+    };
 };
 
 var caretValue = function() {
-    var format = this.parseUShort()
-    check.argument(format == 1 || format == 2 || format == 3,
+    var format = this.parseUShort();
+    check.argument(format === 1 || format === 2 || format === 3,
         'Unsupported CaretValue table version.');
-    if (format == 1) {
-        return { coordinate: this.parseShort() }
-    } else if (format == 2) {
-        return { pointindex: this.parseShort() }
-    } else if (format == 3) {
+    if (format === 1) {
+        return { coordinate: this.parseShort() };
+    } else if (format === 2) {
+        return { pointindex: this.parseShort() };
+    } else if (format === 3) {
         // Device / Variation Index tables unsupported
-        return { coordinate: this.parseShort() }
+        return { coordinate: this.parseShort() };
     }
-}
+};
 
 var ligGlyph = function() {
-    return this.parseList(Parser.pointer(caretValue))
-}
+    return this.parseList(Parser.pointer(caretValue));
+};
 
 var ligCaretList = function() {
     return {
         coverage: this.parsePointer(Parser.coverage),
         ligGlyphs: this.parseList(Parser.pointer(ligGlyph))
-    }
+    };
 };
 
 var markGlyphSets = function() {
-    this.parseUShort() // Version
-    return this.parseList(Parser.pointer(Parser.coverage))
-}
+    this.parseUShort(); // Version
+    return this.parseList(Parser.pointer(Parser.coverage));
+};
 
 function parseGDEFTable(data, start) {
     start = start || 0;
     const p = new Parser(data, start);
     const tableVersion = p.parseVersion(1);
-    check.argument(tableVersion == 1 || tableVersion == 1.2 || tableVersion == 1.3,
+    check.argument(tableVersion === 1 || tableVersion === 1.2 || tableVersion === 1.3,
         'Unsupported GDEF table version.');
     var gdef = {
         version: tableVersion,
@@ -56,8 +55,8 @@ function parseGDEFTable(data, start) {
         markAttachClassDef: p.parsePointer(Parser.classDef)
     };
     if (tableVersion >= 1.2) {
-        gdef.markGlyphSets = p.parsePointer(markGlyphSets)
+        gdef.markGlyphSets = p.parsePointer(markGlyphSets);
     }
-    return gdef
+    return gdef;
 }
 export default { parse: parseGDEFTable };

--- a/src/tables/gdef.js
+++ b/src/tables/gdef.js
@@ -1,0 +1,63 @@
+// The `GDEF` table contains various glyph properties
+// https://docs.microsoft.com/en-us/typography/opentype/spec/gdef
+
+import check from '../check';
+import { Parser } from '../parse';
+import table from '../table';
+
+var attachList = function() {
+    return {
+        coverage: this.parsePointer(Parser.coverage),
+        attachPoints: this.parseList(Parser.pointer(Parser.uShortList))
+    }
+};
+
+var caretValue = function() {
+    var format = this.parseUShort()
+    check.argument(format == 1 || format == 2 || format == 3,
+        'Unsupported CaretValue table version.');
+    if (format == 1) {
+        return { coordinate: this.parseShort() }
+    } else if (format == 2) {
+        return { pointindex: this.parseShort() }
+    } else if (format == 3) {
+        // Device / Variation Index tables unsupported
+        return { coordinate: this.parseShort() }
+    }
+}
+
+var ligGlyph = function() {
+    return this.parseList(Parser.pointer(caretValue))
+}
+
+var ligCaretList = function() {
+    return {
+        coverage: this.parsePointer(Parser.coverage),
+        ligGlyphs: this.parseList(Parser.pointer(ligGlyph))
+    }
+};
+
+var markGlyphSets = function() {
+    this.parseUShort() // Version
+    return this.parseList(Parser.pointer(Parser.coverage))
+}
+
+function parseGDEFTable(data, start) {
+    start = start || 0;
+    const p = new Parser(data, start);
+    const tableVersion = p.parseVersion(1);
+    check.argument(tableVersion == 1 || tableVersion == 1.2 || tableVersion == 1.3,
+        'Unsupported GDEF table version.');
+    var gdef = {
+        version: tableVersion,
+        classDef: p.parsePointer(Parser.classDef),
+        attachList: p.parsePointer(attachList),
+        ligCaretList: p.parsePointer(ligCaretList),
+        markAttachClassDef: p.parsePointer(Parser.classDef)
+    };
+    if (tableVersion >= 1.2) {
+        gdef.markGlyphSets = p.parsePointer(markGlyphSets)
+    }
+    return gdef
+}
+export default { parse: parseGDEFTable };

--- a/test/tables/gdef.js
+++ b/test/tables/gdef.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { hex, unhex } from '../testutil';
+import { unhex } from '../testutil';
 import gdef from '../../src/tables/gdef';
 
 describe('tables/gdef.js', function() {
@@ -25,11 +25,11 @@ describe('tables/gdef.js', function() {
         version: 1,
         attachList: {
             attachPoints: [
-                [11,13,14],
-                [24,25,26],
-                [39,40,41],
-                [4,13,14],
-                [24,25,26]
+                [11, 13, 14],
+                [24, 25, 26],
+                [39, 40, 41],
+                [4, 13, 14],
+                [24, 25, 26]
             ],
             coverage: {
                 format: 2,
@@ -53,24 +53,24 @@ describe('tables/gdef.js', function() {
             ]
         },
         ligCaretList: {
-            coverage: { format: 1, glyphs: [ 1004, 1005, 1007, 1008, 1009 ] },
+            coverage: {format: 1, glyphs: [1004, 1005, 1007, 1008, 1009]},
             ligGlyphs: [
-                  [{coordinate: 2115 } ],
-                  [{coordinate: 1410 }, {coordinate: 2820 } ],
-                  [{coordinate: 2304 } ],
-                  [{coordinate: 1536 }, {coordinate: 3072 } ],
-                  [{coordinate: 1152 }, {coordinate: 2304 }, {coordinate: 3456 } ]
+                  [{coordinate: 2115}],
+                  [{coordinate: 1410}, {coordinate: 2820}],
+                  [{coordinate: 2304}],
+                  [{coordinate: 1536}, {coordinate: 3072}],
+                  [{coordinate: 1152}, {coordinate: 2304}, {coordinate: 3456}]
             ]
         },
         markAttachClassDef: {
             format: 2,
             ranges: [
-              {classId: 1, start: 43, end: 43 },
-              {classId: 2, start: 46, end: 46 },
-              {classId: 4, start: 74, end: 74 },
-              {classId: 1, start: 101, end: 101 },
-              {classId: 2, start: 126, end: 126 }
-            ]
+              {classId: 1, start: 43, end: 43},
+              {classId: 2, start: 46, end: 46},
+              {classId: 4, start: 74, end: 74},
+              {classId: 1, start: 101, end: 101},
+              {classId: 2, start: 126, end: 126}
+           ]
         },
     };
 

--- a/test/tables/gdef.js
+++ b/test/tables/gdef.js
@@ -1,0 +1,80 @@
+import assert from 'assert';
+import { hex, unhex } from '../testutil';
+import gdef from '../../src/tables/gdef';
+
+describe('tables/gdef.js', function() {
+    const data =
+        ' 00 01 00 00 00 0c 00 40 00 78 00 d0 00 02 00 08' +
+        ' 00 65 00 65 00 03 00 f2 00 f2 00 01 02 08 02 08' +
+        ' 00 01 02 0a 02 0a 00 01 02 1b 02 1b 00 01 02 22' +
+        ' 02 22 00 01 03 f3 03 f4 00 02 04 14 04 14 00 03' +
+        ' 00 0e 00 05 00 18 00 30 00 20 00 28 00 30 00 02' +
+        ' 00 01 00 0f 00 13 00 00 00 03 00 0b 00 0d 00 0e' +
+        ' 00 03 00 27 00 28 00 29 00 03 00 04 00 0d 00 0e' +
+        ' 00 03 00 18 00 19 00 1a 00 0e 00 05 00 1c 00 24' +
+        ' 00 32 00 36 00 44 00 01 00 05 03 ec 03 ed 03 ef' +
+        ' 03 f0 03 f1 00 01 00 04 00 01 08 43 00 02 00 06' +
+        ' 00 0a 00 01 05 82 00 01 0b 04 00 01 00 1e 00 02' +
+        ' 00 06 00 0a 00 01 06 00 00 01 0c 00 00 03 00 08' +
+        ' 00 0c 00 10 00 01 04 80 00 01 09 00 00 01 0d 80' +
+        ' 00 02 00 05 00 2b 00 2b 00 01 00 2e 00 2e 00 02' +
+        ' 00 4a 00 4a 00 04 00 65 00 65 00 01 00 7e 00 7e' +
+        ' 00 02';
+
+    const table = {
+        version: 1,
+        attachList: {
+            attachPoints: [
+                [11,13,14],
+                [24,25,26],
+                [39,40,41],
+                [4,13,14],
+                [24,25,26]
+            ],
+            coverage: {
+                format: 2,
+                ranges: [
+                  { end: 19, index: 0, start: 15 }
+                ]
+            }
+        },
+        classDef: {
+            format: 2,
+            ranges: [
+                { classId: 3, start: 101, end: 101 },
+                { classId: 1, start: 242, end: 242 },
+                { classId: 1, start: 520, end: 520 },
+                { classId: 1, start: 522, end: 522 },
+                { classId: 1, start: 539, end: 539 },
+                { classId: 1, start: 546, end: 546 },
+                { classId: 2, start: 1011, end: 1012 },
+                { classId: 3, start: 1044, end: 1044 }
+
+            ]
+        },
+        ligCaretList: {
+            coverage: { format: 1, glyphs: [ 1004, 1005, 1007, 1008, 1009 ] },
+            ligGlyphs: [
+                  [{coordinate: 2115 } ],
+                  [{coordinate: 1410 }, {coordinate: 2820 } ],
+                  [{coordinate: 2304 } ],
+                  [{coordinate: 1536 }, {coordinate: 3072 } ],
+                  [{coordinate: 1152 }, {coordinate: 2304 }, {coordinate: 3456 } ]
+            ]
+        },
+        markAttachClassDef: {
+            format: 2,
+            ranges: [
+              {classId: 1, start: 43, end: 43 },
+              {classId: 2, start: 46, end: 46 },
+              {classId: 4, start: 74, end: 74 },
+              {classId: 1, start: 101, end: 101 },
+              {classId: 2, start: 126, end: 126 }
+            ]
+        },
+    };
+
+    it('can parse a GDEF table', function() {
+        assert.deepEqual(table, gdef.parse(unhex(data)));
+    });
+});


### PR DESCRIPTION
This adds a class to parse the GDEF table. I need this because I'm needing to show the difference between mark and base glyphs in [an application](https://github.com/simoncozens/crowbar).

There's currently no interface to the data yet, because I would appreciate some guidance on how you would like to do it. It seems obvious to me that the GDEF table provides properties on `Glyph` objects, and so I would imagine something like this in `GlyphSet.prototype.get`:

```
     this.glyphs[index].glyphClass = Layout.prototype.getGlyphClass(this.font.tables.gdef.classDef, index)
```

But do we really want to load glyph classes every time a glyph is instantiated?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.

