### PR TITLE
Initialize CFF DICT's _defaultWidthX and _nominalWidthX

### DIFF
--- a/src/tables/cff.js
+++ b/src/tables/cff.js
@@ -384,6 +384,8 @@ function gatherCFFTopDicts(data, start, cffIndex, strings) {
         const topDict = parseCFFTopDict(topDictData, strings);
         topDict._subrs = [];
         topDict._subrsBias = 0;
+        topDict._defaultWidthX = 0;
+        topDict._nominalWidthX = 0;
         const privateSize = topDict.private[0];
         const privateOffset = topDict.private[1];
         if (privateSize !== 0 && privateOffset !== 0) {


### PR DESCRIPTION
As specified by [CFF specification](https://typekit.files.wordpress.com/2013/05/5176.cff.pdf) (see page 24), the defaultWidthX and nominalWidthX operators should have a default value of 0.

## Description
`gatherCFFTopDicts` parses the CFF table's DICT data. It is in charge of assigning correct defaults for the private DICT operator _subrs_. I assumed we would like to also initialize the default values for __defaultWidthX_ and __nominalWidthX_ here, since other calculations rely on there always being  a value for the topDict's __defaultWidthX_ and __nominalWidthX_.

## Motivation and Context
This solves the problem of OTF fonts that don't have a private DICT having all glyphs end up with a width of NaN, since the width calculation expects values for __defaultWidthX_ and __nominalWidthX_.

- https://github.com/opentypejs/opentype.js/issues/417
- https://github.com/opentypejs/opentype.js/issues/440
- https://github.com/opentypejs/opentype.js/issues/397

## How Has This Been Tested?

The following test used to fail their assertion. They now pass.

- Ran the test case from https://github.com/opentypejs/opentype.js/issues/417, it now works without failing the assert.
- Ran the test case from https://github.com/opentypejs/opentype.js/issues/440, it now works without failing the assert.
    -  Also ran the variant from mattlag's comment
- Ran the following variant of the test from https://github.com/opentypejs/opentype.js/issues/397, it now works failing the assert.

```
const fs = require('fs');
const opentype = require('./dist/opentype.js');
const assert = require('assert');

function makeSubFont(font, content) {
  return new opentype.Font({
    familyName: font.names.fontFamily.en,
    styleName: font.names.fontSubfamily.en,
    unitsPerEm: font.unitsPerEm,
    ascender: font.ascender,
    descender: font.descender,
    glyphs: font.stringToGlyphs(Array.from(new Set(content.split(''))).join('')),
  })
}

let font = opentype.loadSync('./SourceHanSans-Regular.otf');
const char = '上';
const advanceWidthChar = font.charToGlyph(char).advanceWidth;

assert.strictEqual(font.charToGlyph(char).advanceWidth, advanceWidthChar, "advanceWidth before getBoundingBox");
font.charToGlyph(char).getBoundingBox();
// works
assert.strictEqual(font.charToGlyph(char).advanceWidth, advanceWidthChar, "advanceWidth after getBoundingBox");

const subFont = makeSubFont(font, "上与乡互他伊作全公制前包单司客工布带开括旅晓朗机村棒游环球的相着离程管糖网罕联至蕾视足踏迹遍频颗高︐︒﹁﹂");

const fileName = 'test.woff';
fs.writeFileSync(fileName, Buffer.from(subFont.toArrayBuffer()));
let newFont = opentype.loadSync(fileName, {});

assert.strictEqual(newFont.charToGlyph(char).advanceWidth, advanceWidthChar, "advanceWidth before getBoundingBox");
newFont.charToGlyph(char).getBoundingBox();
// does not work
assert.strictEqual(newFont.charToGlyph(char).advanceWidth, advanceWidthChar, "advanceWidth after getBoundingBox");
```

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
