### PR TITLE
Added the support of loading from http url in node environment.

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -373,7 +373,7 @@ function parseBuffer(buffer, opt) {
  */
 function load(url, callback, opt) {
     const isNode = typeof window === 'undefined';
-    const loadFn = isNode ? loadFromFile : loadFromUrl;
+    const loadFn = isNode && !opt.isUrl ? loadFromFile : loadFromUrl;
 
     return new Promise((resolve, reject) => {
         loadFn(url, function(err, arrayBuffer) {

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -372,6 +372,7 @@ function parseBuffer(buffer, opt) {
  * @param  {Function} callback - The callback.
  */
 function load(url, callback, opt) {
+    opt = (opt === undefined || opt === null) ?  {} : opt;
     const isNode = typeof window === 'undefined';
     const loadFn = isNode && !opt.isUrl ? loadFromFile : loadFromUrl;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've made an extra configuration change. I added support to pass isUrl (boolean) in opt parameter. If passed true it will allow user to load font from an http url in node environment as well.

## Motivation and Context
I myself was using the library and needed to load font from url in backend code written in node js. So now this will help user to use urls even in backend code. And previous behaviour is preserved.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
