### PR TITLE
minor cleanup on doc comments and error messages

### DIFF
--- a/src/substitution.js
+++ b/src/substitution.js
@@ -157,7 +157,7 @@ Substitution.prototype.getLigatures = function(feature, script, language) {
  * Add or modify a single substitution (lookup type 1)
  * Format 2, more flexible, is always used.
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
- * @param {Object} substitution - { sub: id, by: id } (format 2 is not supported)
+ * @param {Object} substitution - { sub: id, by: id } (format 1 is not supported)
  * @param {string} [script='DFLT']
  * @param {string} [language='dflt']
  */

--- a/src/substitution.js
+++ b/src/substitution.js
@@ -157,7 +157,7 @@ Substitution.prototype.getLigatures = function(feature, script, language) {
  * Add or modify a single substitution (lookup type 1)
  * Format 2, more flexible, is always used.
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
- * @param {Object} substitution - { sub: id, delta: number } for format 1 or { sub: id, by: id } for format 2.
+ * @param {Object} substitution - { sub: id, by: id } (format 2 is not supported)
  * @param {string} [script='DFLT']
  * @param {string} [language='dflt']
  */
@@ -168,7 +168,7 @@ Substitution.prototype.addSingle = function(feature, substitution, script, langu
         coverage: {format: 1, glyphs: []},
         substitute: []
     });
-    check.assert(subtable.coverage.format === 1, 'Ligature: unable to modify coverage table format ' + subtable.coverage.format);
+    check.assert(subtable.coverage.format === 1, 'Single: unable to modify coverage table format ' + subtable.coverage.format);
     const coverageGlyph = substitution.sub;
     let pos = this.binSearch(subtable.coverage.glyphs, coverageGlyph);
     if (pos < 0) {
@@ -180,7 +180,7 @@ Substitution.prototype.addSingle = function(feature, substitution, script, langu
 };
 
 /**
- * Add or modify an alternate substitution (lookup type 1)
+ * Add or modify an alternate substitution (lookup type 3)
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
  * @param {Object} substitution - { sub: id, by: [ids] }
  * @param {string} [script='DFLT']
@@ -193,7 +193,7 @@ Substitution.prototype.addAlternate = function(feature, substitution, script, la
         coverage: {format: 1, glyphs: []},
         alternateSets: []
     });
-    check.assert(subtable.coverage.format === 1, 'Ligature: unable to modify coverage table format ' + subtable.coverage.format);
+    check.assert(subtable.coverage.format === 1, 'Alternate: unable to modify coverage table format ' + subtable.coverage.format);
     const coverageGlyph = substitution.sub;
     let pos = this.binSearch(subtable.coverage.glyphs, coverageGlyph);
     if (pos < 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Some minor fixes to doc comments and error messages. Lookup type ids were incoherent and all error messages began with "Ligature:" regardless of type. Also, type 1 of 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found those wrong messages a bit confusing when I encountered them while working on the implementation for GSUB lookup type 2 (Multiple Substitution). Might confuse other contributors and users as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just some minor textual changes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] ~I have added tests to cover my changes.~ not applicable
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
