### PR TITLE
implement writing of coverage format 2

### DIFF
--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -287,6 +287,25 @@ describe('tables/gsub.js', function() {
         assert.deepEqual(gsub.make(gsubTable).encode(), expectedData);
     });
 
+    it('can write a lookup with coverage table format 2', function() {
+        // https://docs.microsoft.com/de-de/typography/opentype/spec/chapter2#coverage-table
+        // https://docs.microsoft.com/de-de/typography/opentype/spec/gsub#EX6 (extended with two more ranges)
+
+        const expectedData = unhexArray('0001 0006 00C0   0002 0003   0019 001A 0000   004E 0057 0002   0060 0063 000C');
+        assert.deepEqual(makeLookup(1, {
+            substFormat: 1,
+            coverage: {
+                format: 2,
+                ranges: [
+                    { start: 25, end: 26, index: 0 },
+                    { start: 78, end: 87, index: 2 },
+                    { start: 96, end: 99, index: 12 }
+                ]
+            },
+            deltaGlyphId: 0xc0
+        }), expectedData);
+    });
+
     //// Lookup type 1 ////////////////////////////////////////////////////////
     it('can write lookup1 substFormat 1', function() {
         const expectedData = unhexArray('0001 0006 00C0   0001 0004 003C 0040 004B 004F');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implements writing of coverage tables in coverage format 2, which uses glyph ranges instead of a list of glyphs, see https://docs.microsoft.com/de-de/typography/opentype/spec/chapter2#coverage-format-2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Loading a font that contained a coverage table with coverage format 2 and trying to save it failed with the error message
> Can't create coverage table format 2 yet.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Loaded a font that contains at least one coverage table with coverage format 2 (e.g. this [test font](https://github.com/opentypejs/opentype.js/files/5403238/testfont_coverage_format_2.zip) i created) and save it (using `font.download()` or `font.toArrayBuffer()`). It will fail before the fix and work fine afterwards. I verified that the lookup table is still in the file and it opens fine using Windows Font viewer and FontForge.

Also, a new test case was created for this feature according to https://docs.microsoft.com/de-de/typography/opentype/spec/gsub#EX6 (and extended to three ranges, that's how I found out that I needed to make the changes to `Table()` as well). All other test cases still pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) - _this fixes #223, which was closed but never really fixed._
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [X] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
