### PR TITLE
Handle undefined chararray

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -67,6 +67,9 @@ sizeOf.CHAR = constant(1);
  * @returns {Array}
  */
 encode.CHARARRAY = function(v) {
+    if (typeof v === 'undefined') {
+        v = '';
+    }
     const b = [];
     for (let i = 0; i < v.length; i += 1) {
         b[i] = v.charCodeAt(i);

--- a/src/types.js
+++ b/src/types.js
@@ -69,6 +69,7 @@ sizeOf.CHAR = constant(1);
 encode.CHARARRAY = function(v) {
     if (typeof v === 'undefined') {
         v = '';
+        console.warn('Undefined CHARARRAY encountered and treated as an empty string. This is probably caused by a missing glyph name.');
     }
     const b = [];
     for (let i = 0; i < v.length; i += 1) {

--- a/src/types.js
+++ b/src/types.js
@@ -83,6 +83,9 @@ encode.CHARARRAY = function(v) {
  * @returns {number}
  */
 sizeOf.CHARARRAY = function(v) {
+    if (typeof v === 'undefined') {
+        return 0;
+    }
     return v.length;
 };
 

--- a/test/types.js
+++ b/test/types.js
@@ -18,6 +18,11 @@ describe('types.js', function() {
         assert.equal(sizeOf.CHARARRAY('A/B'), 3);
     });
 
+    it('can handle undefined as CHARARRAY', function() {
+        assert.equal(hex(encode.CHARARRAY(undefined)), '');
+        assert.equal(sizeOf.CHARARRAY(undefined), 0);
+    });
+
     it('can handle USHORT', function() {
         assert.equal(hex(encode.USHORT(0xCAFE)), 'CA FE');
         assert.equal(sizeOf.USHORT(0xCAFE), 2);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If `undefined` is passed as the argument for `encode.CHARSET` or `sizeOf.CHARSET`, treat it as an empty string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some fonts contain (or are at least parsed with) glyphs whose name is `undefined`. Saving these fonts will fail with the following error:
> Uncaught TypeError: Cannot read property 'length' of undefined
>     at encode.CHARARRAY (types.js:71)
>     at Object.encode.OBJECT (types.js:871)
>     at Object.encode.INDEX (types.js:710)
>     at sizeOf.INDEX (types.js:739)
>     at Object.sizeOf.TABLE (types.js:946)
>     at Table.sizeOf (table.js:47)
>     at Object.makeCFFTable [as make] (cff.js:1301)
>     at Object.fontToSfntTable [as fontToTable] (sfnt.js:288)
>     at Font.toTables (font.js:483)
>     at Font.toArrayBuffer (font.js:497)
> 

I'll create this PR as a draft for discussion because I'm not sure whether this just fixes a symptom instead of the cause. I wasn't able to find out whether glyphs without a name are actually valid according to the OpenType spec.
In #240 it was proposed to derive the glyph name if it is not set: https://github.com/opentypejs/opentype.js/issues/240#issuecomment-260134716 - that sounds good to me. Should we still implement this fix so that in any case `undefined` as a CHARARRAY is treated as an empty string, maybe loggin an error to the console? That way, the writing process wouldn't simply fail and prevent the user from saving the font.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A font that was parsed with some glyph names being `undefined` could not be saved before the fix, and can be after. I also added a test case for the fix.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - fixes #240 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
