### PR TITLE
Fix Quadratic to Cubic rounding issue in Glyph to CFF Ops stage

### DIFF
--- a/src/tables/cff.js
+++ b/src/tables/cff.js
@@ -1167,14 +1167,15 @@ function glyphToOps(glyph) {
             const _23 = 2 / 3;
 
             // We're going to create a new command so we don't change the original path.
+            // Since all coordinates are relative, we round() them ASAP to avoid propagating errors.
             cmd = {
                 type: 'C',
                 x: cmd.x,
                 y: cmd.y,
-                x1: _13 * x + _23 * cmd.x1,
-                y1: _13 * y + _23 * cmd.y1,
-                x2: _13 * cmd.x + _23 * cmd.x1,
-                y2: _13 * cmd.y + _23 * cmd.y1
+                x1: Math.round(_13 * x + _23 * cmd.x1),
+                y1: Math.round(_13 * y + _23 * cmd.y1),
+                x2: Math.round(_13 * cmd.x + _23 * cmd.x1),
+                y2: Math.round(_13 * cmd.y + _23 * cmd.y1)
             };
         }
 

--- a/test/tables/cff.js
+++ b/test/tables/cff.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import { hex } from '../testutil';
+import Glyph from '../../src/glyph';
+import glyphset from '../../src/glyphset';
+import Path from '../../src/path';
+import cff from '../../src/tables/cff';
+
+describe('tables/cff.js', function () {
+    const data =
+        '01 00 04 01 00 01 01 01 03 70 73 00 01 01 01 32 ' +
+        'F8 1B 00 F8 1C 02 F8 1C 03 F8 1D 04 1D 00 00 00 ' +
+        '55 0F 1D 00 00 00 58 11 8B 1D 00 00 00 80 12 1E ' +
+        '0A 12 5F 1E 0F 1E 0F 1E 0A 12 5F 1E 0F 1E 0F 0C ' +
+        '07 00 04 01 01 02 04 06 0B 30 66 6E 77 6E 62 75 ' +
+        '6D 70 73 00 00 00 01 8A 00 02 01 01 03 23 9B 0E ' +
+        '9B 8B 8B 15 8C 8D 8B 8B 8C 89 08 89 8B 15 8C 8D ' +
+        '8B 8B 8C 89 08 89 8B 15 8C 8D 8B 8B 8C 89 08 0E';
+
+    it('can make a cff tag table', function () {
+        const options = {
+            unitsPerEm: 8,
+            version: '0',
+            fullName: 'fn',
+            postScriptName: 'ps',
+            familyName: 'fn',
+            weightName: 'wn',
+            fontBBox: [0, 0, 0, 0],
+        };
+        const path = new Path();
+        path.moveTo(0, 0);
+        path.quadraticCurveTo(1, 3, 2, 0);
+        path.moveTo(0, 0);
+        path.quadraticCurveTo(1, 3, 2, 0);
+        path.moveTo(0, 0);
+        path.quadraticCurveTo(1, 3, 2, 0);
+        const bumpsGlyph = new Glyph({ name: 'bumps', path, advanceWidth: 16 });
+        const nodefGlyph = new Glyph({ name: 'nodef', path: new Path(), advanceWidth: 16 });
+        const glyphSetFont = { unitsPerEm: 8 };
+        const glyphs = new glyphset.GlyphSet(glyphSetFont, [nodefGlyph, bumpsGlyph]);
+
+        assert.deepEqual(data, hex(cff.make(glyphs, options).encode()));
+    });
+
+});


### PR DESCRIPTION
This PR fix the relative-coordinate error propagation found in the Quadratic to Cubic conversion stage of the CFF table ops building.

## Description

CFF does not support Quadratic command so `glyphToOps` generate a rounded Cubic Op which later create a coordinate deviations for every following commands.

## Motivation and Context

This fix https://github.com/opentypejs/opentype.js/issues/467

## How Has This Been Tested?
I tested this change on ~110 quadratic scenarios and it gives me a much better result than before.

## Screenshots (if appropriate):
Draw 3 coordinate-identical quadratic curves (`M0,0 Q1,3,2,0 M0,0 Q1,3,2,0 M0,0 Q1,3,2,0`)

Before : the rounding error propagation shift every curves :negative_squared_cross_mark: 
![](https://user-images.githubusercontent.com/5113053/108616503-255abd80-740e-11eb-8a27-9348a5d0daa8.png)

After : the 3 identical curve exactly overlap :heavy_check_mark: 
![](https://user-images.githubusercontent.com/5113053/108617394-46bfa780-7416-11eb-9783-0b4c469cd71c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
