### PR TITLE
Update to use Buffer.alloc in place of deprecated new Buffer()

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -17,7 +17,7 @@ function nodeBufferToArrayBuffer(buffer) {
 }
 
 function arrayBufferToNodeBuffer(ab) {
-    const buffer = new Buffer(ab.byteLength);
+    const buffer = Buffer.alloc(ab.byteLength);
     const view = new Uint8Array(ab);
     for (let i = 0; i < buffer.length; ++i) {
         buffer[i] = view[i];


### PR DESCRIPTION
See Issue #473. Running the sample code, shows a warning. This PR fixes the code to update to the new node Buffer API.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [X] I have updated the **README** accordingly, but mostly because I don't think it needs changing.
- [X] I have read the **CONTRIBUTING** document.
