### PR TITLE
GSUB lookup table type 7 subtable format 1

### DIFF
--- a/src/features/featureQuery.js
+++ b/src/features/featureQuery.js
@@ -150,7 +150,7 @@ function chainingSubstitutionFormat3(contextParams, subtable) {
             const lookupTable = this.getLookupByIndex(lookupListIndex);
             for (let s = 0; s < lookupTable.subtables.length; s++) {
                 let subtable = lookupTable.subtables[s];
-                let lookup = this.getLookupMethod(lookupTable, subtable);
+                let lookup;
                 let substitutionType = this.getSubstitutionType(lookupTable, subtable);
 
                 if (substitutionType === '71') {
@@ -158,6 +158,8 @@ function chainingSubstitutionFormat3(contextParams, subtable) {
                     substitutionType = this.getSubstitutionType(subtable, subtable.extension);
                     lookup = this.getLookupMethod(subtable, subtable.extension);
                     subtable = subtable.extension;
+                } else {
+                    lookup = this.getLookupMethod(lookupTable, subtable);
                 }
 
                 if (substitutionType === '12') {
@@ -379,13 +381,15 @@ FeatureQuery.prototype.lookupFeature = function (query) {
         for (let s = 0; s < subtables.length; s++) {
             let subtable = subtables[s];
             let substType = this.getSubstitutionType(lookupTable, subtable);
-            let lookup = this.getLookupMethod(lookupTable, subtable);
+            let lookup;
 
             if (substType === '71') {
                 // This is an extension subtable, so lookup the target subtable
                 substType = this.getSubstitutionType(subtable, subtable.extension);
                 lookup = this.getLookupMethod(subtable, subtable.extension);
                 subtable = subtable.extension;
+            } else {
+                lookup = this.getLookupMethod(lookupTable, subtable);
             }
 
             let substitution;

--- a/src/features/featureQuery.js
+++ b/src/features/featureQuery.js
@@ -149,15 +149,25 @@ function chainingSubstitutionFormat3(contextParams, subtable) {
             const lookupListIndex = lookupRecord.lookupListIndex;
             const lookupTable = this.getLookupByIndex(lookupListIndex);
             for (let s = 0; s < lookupTable.subtables.length; s++) {
-                const subtable = lookupTable.subtables[s];
-                const lookup = this.getLookupMethod(lookupTable, subtable);
-                const substitutionType = this.getSubstitutionType(lookupTable, subtable);
+                let subtable = lookupTable.subtables[s];
+                let lookup = this.getLookupMethod(lookupTable, subtable);
+                let substitutionType = this.getSubstitutionType(lookupTable, subtable);
+
+                if (substitutionType === '71') {
+                    // This is an extension subtable, so lookup the target subtable
+                    substitutionType = this.getSubstitutionType(subtable, subtable.extension);
+                    lookup = this.getLookupMethod(subtable, subtable.extension);
+                    subtable = subtable.extension;
+                }
+
                 if (substitutionType === '12') {
                     for (let n = 0; n < inputLookups.length; n++) {
                         const glyphIndex = contextParams.get(n);
                         const substitution = lookup(glyphIndex);
                         if (substitution) substitutions.push(substitution);
                     }
+                } else {
+                    throw new Error(`Substitution type ${substitutionType} is not supported in chaining substitution`);
                 }
             }
         }
@@ -367,9 +377,17 @@ FeatureQuery.prototype.lookupFeature = function (query) {
         const lookupTable = lookups[l];
         const subtables = this.getLookupSubtables(lookupTable);
         for (let s = 0; s < subtables.length; s++) {
-            const subtable = subtables[s];
-            const substType = this.getSubstitutionType(lookupTable, subtable);
-            const lookup = this.getLookupMethod(lookupTable, subtable);
+            let subtable = subtables[s];
+            let substType = this.getSubstitutionType(lookupTable, subtable);
+            let lookup = this.getLookupMethod(lookupTable, subtable);
+
+            if (substType === '71') {
+                // This is an extension subtable, so lookup the target subtable
+                substType = this.getSubstitutionType(subtable, subtable.extension);
+                lookup = this.getLookupMethod(subtable, subtable.extension);
+                subtable = subtable.extension;
+            }
+
             let substitution;
             switch (substType) {
                 case '11':

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -213,7 +213,28 @@ describe('tables/gsub.js', function() {
     // TODO (no example in the doc from Microsoft)
 
     //// Lookup type 7 ////////////////////////////////////////////////////////
-    // TODO (no example in the doc from Microsoft)
+    it('can parse lookup7 subtable format 1', function() {
+
+        const data =
+            '00 01' +                    // substFormat
+            '00 01' +                    // extensionLookupType
+            '00 00 00 08' +              //	extensionOffset
+            '0001 0006 00C0   0002 0001 004E 0058 0000' // data equal to that from the lookup1 substFormat 1 test
+            ;
+        const parsed = parseLookup(7, data);
+        assert.deepEqual(parsed, {
+            extension: { // object equal to that from the lookup1 substFormat 1 test
+                substFormat: 1,
+                coverage: {
+                    format: 2,
+                    ranges: [{ start: 0x4e, end: 0x58, index: 0 }]
+                },
+                deltaGlyphId: 0xc0
+            },
+            lookupType: 1,
+            substFormat: 1
+        });
+    });
 
     //// Lookup type 8 ////////////////////////////////////////////////////////
     it('can parse lookup8', function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
_In featureQuery.js:chainingSubstitutionFormat3_
- Modify var types of subtable, lookup, and substitutionType to be lets so they can be mutated in the next step.
- Detect substitution type "71" which means lookup table type 7 and format 1. 
- When detected, mutate the substitution type and lookup method based on the linked extension subtable
- Finally update the subtable variable to be the extension table
- Throw an error if the chained substitution type is not handled. This will avoid fonts that use chaining substitutions from silently rendering incorrectly if they use an unhandled changed substitution.

_In featureQuery.js:FeatureQuery.prototype.lookupFeature_

Same changes as above.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses issue #415 

GSUB tables have a lookup table type 7 called the Extension Substitution Subtable. Only one format officially exists (format 1). 
See the [OpenType spec page](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-7-extension-substitution).

Per the spec, Extension tables are used in fonts that use a large number of substitution subtables. Fonts for scripts where letters are connected are a situation where many substitutions are needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
So far I have tested this on 3 custom fonts in my library, one of which contains type 7 lookup tables and 2 that do not. Unfortunately I do not have the license to upload these fonts in the PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [X] I have read the **CONTRIBUTING** document.
