### PR TITLE
GPOS lookupType 9 support

### DIFF
--- a/src/position.js
+++ b/src/position.js
@@ -36,6 +36,8 @@ Position.prototype.getKerningValue = function(kerningLookups, leftIndex, rightIn
         const subtables = kerningLookups[i].subtables;
         for (let j = 0; j < subtables.length; j++) {
             const subtable = subtables[j];
+            // Subtables not supported come with an error
+            if (subtable.error) continue;
             const covIndex = this.getCoverageIndex(subtable.coverage, leftIndex);
             if (covIndex < 0) continue;
             switch (subtable.posFormat) {
@@ -72,7 +74,13 @@ Position.prototype.getKerningValue = function(kerningLookups, leftIndex, rightIn
  */
 Position.prototype.getKerningTables = function(script, language) {
     if (this.font.tables.gpos) {
-        return this.getLookupTables(script, language, 'kern', 2);
+        const featureTable = this.getFeatureTable(script, language, 'kern');
+        return this.getLookupTables(
+            script,
+            language,
+            'kern',
+            featureTable && featureTable.lookupListIndexes.length ? this.font.tables.gpos.lookups[featureTable.lookupListIndexes[0]].lookupType : 2
+        );
     }
 };
 

--- a/src/tables/gpos.js
+++ b/src/tables/gpos.js
@@ -82,7 +82,10 @@ subtableParsers[5] = function parseLookup5() { return { error: 'GPOS Lookup 5 no
 subtableParsers[6] = function parseLookup6() { return { error: 'GPOS Lookup 6 not supported' }; };
 subtableParsers[7] = function parseLookup7() { return { error: 'GPOS Lookup 7 not supported' }; };
 subtableParsers[8] = function parseLookup8() { return { error: 'GPOS Lookup 8 not supported' }; };
-subtableParsers[9] = function parseLookup9() { return { error: 'GPOS Lookup 9 not supported' }; };
+subtableParsers[9] = function parseLookup9() {
+    check.argument(this.parseUShort() === 1, 'GPOS lookup type 9 format must be 1.');
+    return this.parsePointer32(subtableParsers[this.parseUShort()]);
+};
 
 // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos
 function parseGposTable(data, start) {

--- a/test/tables/gpos.js
+++ b/test/tables/gpos.js
@@ -138,4 +138,23 @@ describe('tables/gpos.js', function() {
             ]
         });
     });
+
+    //// Lookup type 9 ////////////////////////////////////////////////////////
+    it('can parse lookup9 extensionLookupType2 PairPosFormat1', function() {
+        // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning
+        const data = '0001 0002 00000008 0001 001E 0004 0001 0002 000E 0016   0001 0059 FFE2 FFEC 0001 0059 FFD8 FFE7   0001 0002 002D 0031';
+        assert.deepEqual(parseLookup(9, data), {
+            posFormat: 1,
+            coverage: {
+                format: 1,
+                glyphs: [0x2d, 0x31]
+            },
+            valueFormat1: 4,
+            valueFormat2: 1,
+            pairSets: [
+                [{ secondGlyph: 0x59, value1: { xAdvance: -30 }, value2: { xPlacement: -20 } }],
+                [{ secondGlyph: 0x59, value1: { xAdvance: -40 }, value2: { xPlacement: -25 } }]
+            ]
+        });
+    });
 });


### PR DESCRIPTION
## Description
Add support for GPOS lookupType 9 to be able to manage other extended lookupType. 🤩 

## Motivation and Context
I noticed, by using this font [WorkSans](https://fonts.google.com/specimen/Work+Sans), I was not able to get kerning values. Diving into this problem, I found it was because GPOS lookupType 9 was not supported and only lookupType 2 was used in getKerningTables.

## How Has This Been Tested?
- Added an unit test included lookupType 9 data
- Tested on WorkSans font. Now we can get kerning values on this one 💪 
- Tested on ProximaNova font to ensure that already lookupType 2 still working as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
