### PR TITLE
fix: update isNode implementation

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -13,7 +13,7 @@ import { CmapEncoding, GlyphNames, addGlyphNames } from './encoding';
 import parse from './parse';
 import BoundingBox from './bbox';
 import Path from './path';
-import { nodeBufferToArrayBuffer } from './util';
+import { nodeBufferToArrayBuffer, isNode } from './util';
 import cmap from './tables/cmap';
 import cff from './tables/cff';
 import fvar from './tables/fvar';
@@ -383,8 +383,7 @@ function parseBuffer(buffer, opt) {
  */
 function load(url, callback, opt) {
     opt = (opt === undefined || opt === null) ?  {} : opt;
-    const isNode = typeof window === 'undefined';
-    const loadFn = isNode && !opt.isUrl ? loadFromFile : loadFromUrl;
+    const loadFn = isNode() && !opt.isUrl ? loadFromFile : loadFromUrl;
 
     return new Promise((resolve, reject) => {
         loadFn(url, function(err, arrayBuffer) {

--- a/src/util.js
+++ b/src/util.js
@@ -3,7 +3,9 @@ function isBrowser() {
 }
 
 function isNode() {
-    return typeof window === 'undefined';
+    return typeof process !== 'undefined' &&
+        process.versions != null &&
+        process.versions.node != null;
 }
 
 function nodeBufferToArrayBuffer(buffer) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

isNode previously assumed that an environment without a window was 'node'.   Unfortunately is also suggests a 'worker' environment.

In the context of the code, a node environment has access to the file system, but a worker is more like the browser environment.

Updated isNode to check the presence of values in `process`, instead of leveraging the lack of a window.

## Motivation and Context

This should fix issues with fonts attempting to read via readFileSync instead of XHR/fetch when running in a web worker.

[Issue 174](https://github.com/opentypejs/opentype.js/issues/174)

## How Has This Been Tested?
As this is a runtime behavior - testing via unit-test is difficult, and probably just a simulation

Ran changes in Node, Browser, and Worker environments

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
