### PR TITLE
Add option for leftSideBearing in new Glyph

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ A Glyph is an individual mark that often corresponds to a character. Some glyphs
 * `unicodes`: The list of unicode values for this glyph (most of the time this will be 1, can also be empty).
 * `index`: The index number of the glyph.
 * `advanceWidth`: The width to advance the pen when drawing this glyph.
+* `leftSideBearing`: The horizontal distance from the previous character to the origin (`0, 0`); a negative value indicates an overhang
 * `xMin`, `yMin`, `xMax`, `yMax`: The bounding box of the glyph.
 * `path`: The raw, unscaled path of the glyph.
 

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -87,7 +87,7 @@ Glyph.prototype.bindConstructorValues = function(options) {
     if ('advanceWidth' in options) {
         this.advanceWidth = options.advanceWidth;
     }
-    
+
     if ('leftSideBearing' in options) {
         this.leftSideBearing = options.leftSideBearing;
     }

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -23,6 +23,7 @@ function getPathDefinition(glyph, path) {
         }
     };
 }
+
 /**
  * @typedef GlyphOptions
  * @type Object
@@ -34,6 +35,7 @@ function getPathDefinition(glyph, path) {
  * @property {number} [xMax]
  * @property {number} [yMax]
  * @property {number} [advanceWidth]
+ * @property {number} [leftSideBearing]
  */
 
 // A Glyph is an individual mark that often corresponds to a character.
@@ -84,6 +86,10 @@ Glyph.prototype.bindConstructorValues = function(options) {
 
     if ('advanceWidth' in options) {
         this.advanceWidth = options.advanceWidth;
+    }
+    
+    if ('leftSideBearing' in options) {
+        this.leftSideBearing = options.leftSideBearing;
     }
 
     // The path for a glyph is the most memory intensive, and is bound as a value

--- a/test/glyph.js
+++ b/test/glyph.js
@@ -1,5 +1,5 @@
 import assert  from 'assert';
-import { loadSync } from '../src/opentype';
+import { loadSync, Glyph, Path } from '../src/opentype';
 
 describe('glyph.js', function() {
     describe('lazy loading', function() {
@@ -66,6 +66,24 @@ describe('glyph.js', function() {
             assert.equal(box.y1, -103);
             assert.equal(box.x2, 688);
             assert.equal(box.y2, 701);
+        });
+    });
+
+    describe('new Glyph', function() {
+        let glyph = new Glyph({
+            name: 'Test Glyph',
+            unicode: 65,
+            path: new Path(),
+            advanceWidth: 400,
+            leftSideBearing: -100
+        });
+
+        it('verifies that the options have all been set', function() {
+            assert.equal(glyph.name, 'Test Glyph');
+            assert.equal(glyph.unicode, 65);
+            assert.equal(glyph.advanceWidth, 400);
+            assert.equal(glyph.leftSideBearing, -100);
+            assert.deepEqual(glyph.unicodes, [65]);
         });
     });
 });


### PR DESCRIPTION
## Description

This is the proposed solution for #500, wherein the leftSideBearing option should be supported by `bindConstructorValues`, allowing the value to be set from within the constructor.

## Motivation and Context

Before that, the `leftSideBearing` property had to be manually assigned after constructing the object (see issue #500 for details).

## How Has This Been Tested?

A test case in `test/glyph.js` has been added, checking that the value is correctly set from the `options` object.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
