### PR TITLE
Replaced concat with push for performance

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -763,8 +763,14 @@ encode.DICT = function(m) {
         const k = parseInt(keys[i], 0);
         const v = m[k];
         // Value comes before the key.
-        d = d.concat(encode.OPERAND(v.value, v.type));
-        d = d.concat(encode.OPERATOR(k));
+        const enc1 = encode.OPERAND(v.value, v.type);
+        const enc2 = encode.OPERATOR(k);
+        for (let j = 0; j < enc1.length; j++) {
+            d.push(enc1[j]);
+        }
+        for (let j = 0; j < enc2.length; j++) {
+            d.push(enc2[j]);
+        }
     }
 
     return d;
@@ -800,19 +806,34 @@ encode.OPERAND = function(v, type) {
     if (Array.isArray(type)) {
         for (let i = 0; i < type.length; i += 1) {
             check.argument(v.length === type.length, 'Not enough arguments given for type' + type);
-            d = d.concat(encode.OPERAND(v[i], type[i]));
+            const enc1 = encode.OPERAND(v[i], type[i]);
+            for (let j = 0; j < enc1.length; j++) {
+                d.push(enc1[j]);
+            }
         }
     } else {
         if (type === 'SID') {
-            d = d.concat(encode.NUMBER(v));
+            const enc1 = encode.NUMBER(v);
+            for (let j = 0; j < enc1.length; j++) {
+                d.push(enc1[j]);
+            }
         } else if (type === 'offset') {
             // We make it easy for ourselves and always encode offsets as
             // 4 bytes. This makes offset calculation for the top dict easier.
-            d = d.concat(encode.NUMBER32(v));
+            const enc1 = encode.NUMBER32(v);
+            for (let j = 0; j < enc1.length; j++) {
+                d.push(enc1[j]);
+            }
         } else if (type === 'number') {
-            d = d.concat(encode.NUMBER(v));
+            const enc1 = encode.NUMBER(v);
+            for (let j = 0; j < enc1.length; j++) {
+                d.push(enc1[j]);
+            }
         } else if (type === 'real') {
-            d = d.concat(encode.REAL(v));
+            const enc1 = encode.REAL(v);
+            for (let j = 0; j < enc1.length; j++) {
+                d.push(enc1[j]);
+            }
         } else {
             throw new Error('Unknown operand type ' + type);
             // FIXME Add support for booleans
@@ -847,7 +868,10 @@ encode.CHARSTRING = function(ops) {
 
     for (let i = 0; i < length; i += 1) {
         const op = ops[i];
-        d = d.concat(encode[op.type](op.value));
+        const enc1 = encode[op.type](op.value);
+        for (let j = 0; j < enc1.length; j++) {
+            d.push(enc1[j]);
+        }
     }
 
     if (wmm) {
@@ -914,10 +938,12 @@ encode.TABLE = function(table) {
 
         if (field.type === 'TABLE') {
             subtableOffsets.push(d.length);
-            d = d.concat([0, 0]);
+            d.push(...[0, 0]);
             subtables.push(bytes);
         } else {
-            d = d.concat(bytes);
+            for (let j = 0; j < bytes.length; j++) {
+                d.push(bytes[j]);
+            }
         }
     }
 
@@ -927,7 +953,9 @@ encode.TABLE = function(table) {
         check.argument(offset < 65536, 'Table ' + table.tableName + ' too big.');
         d[o] = offset >> 8;
         d[o + 1] = offset & 0xff;
-        d = d.concat(subtables[i]);
+        for (let j = 0; j < subtables[i].length; j++) {
+            d.push(subtables[i][j]);
+        }
     }
 
     return d;


### PR DESCRIPTION
## Description
Replaces instances of `d = d.concat(...)` with `push` within encoding functions for improved performance per #512.  Should not impact results. 

## Motivation and Context
This version is faster, particularly on Firefox.  As a test, I ran `window.font.download()` in the console of the https://opentype.js.org/ site.  In Firefox the change reduced runtime from 1,341ms to 190ms.  Chrome experienced a more modest improvement from 203ms to 166ms.  The ability to quickly generate custom font files is important for my project [Scribe OCR](https://github.com/Balearica/scribeocr), and I'm sure others as well. 

## How Has This Been Tested?
The unit tests pass and I am using this version in my live site.  Additionally, the change is conceptually simple and narrow in scope. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
