### PR TITLE
Gracefully handle unsupported WOFF2 parsing

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -207,6 +207,9 @@ function parseBuffer(buffer, opt) {
 
         numTables = parse.getUShort(data, 12);
         tableEntries = parseWOFFTableEntries(data, numTables);
+    } else if (signature === 'wOF2') {
+        var issue = "https://github.com/opentypejs/opentype.js/issues/183#issuecomment-1147228025"
+        throw new Error('WOFF2 require an external decompressor library, see examples at: ' + issue);
     } else {
         throw new Error('Unsupported OpenType signature ' + signature);
     }


### PR DESCRIPTION
## Description

WOFF2 is becoming more and more popular and is now the default font format in font.google.com

So Opentype.js is more and more expected to parse and generate WOFF2.

However WOFF2 compression (as WASM) would bloat the opentype.js dist file by ~1400 KB.

A more modular approach would be to let the end-user do the WOFF compress/decompress wrapping if they need it.

## Motivation and Context

This PR aim to solve this lack of support by pointing the user to [a wrapping example](https://github.com/opentypejs/opentype.js/issues/183#issuecomment-1147228025) if they try the directly load a WOFF2 file into opentype.js

## How Has This Been Tested?

By loading a WOFF2 into opentype.js without decompresing it beforehand and looking at the reason given by the trown exception.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/5113053/172139843-c089d71d-bdbd-4d64-8e27-bf9cc451527a.png)

