### PR TITLE
Don't attempt to parse meta table tags "appl" and "bild". Fixes #522

### DIFF
--- a/src/tables/meta.js
+++ b/src/tables/meta.js
@@ -21,6 +21,8 @@ function parseMetaTable(data, start) {
         const tag = p.parseTag();
         const dataOffset = p.parseULong();
         const dataLength = p.parseULong();
+        if (tag === 'appl' || tag === 'bild')
+           continue;
         const text = decode.UTF8(data, start + dataOffset, dataLength);
 
         tags[tag] = text;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

As described in  #522: Attempting to parse certain fonts that define `appl` and `bild` tags in the `meta` tabke crashes Google Chrome/Chromium/Safari with "RangeError: Maximum call stack size exceeded."

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

See the detailed explanation in the issue. The font loads on the page served with `npm start` and this version of the code.

## Notes:

* instead of dropping the known incompatible/non-ASCII tags (`appl`, `bild`), we could drop all tags that are unknown (not `dlng`, `slng`)
* instead of dropping the tags, we could keep them, but use the un-parsed binary data. This way, the font could be re-build again without loss

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
