### PR TITLE
font inspector: fix headline floating when table section with "Undefined" is expanded

### DIFF
--- a/site.css
+++ b/site.css
@@ -173,6 +173,7 @@ a {
     margin: 0;
     cursor: pointer;
     background-color: #f8f8f8;
+    clear: both;
 }
 
 #font-data h3.expanded::before {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Just a small visual fix for headlines following an expanded table section that only contains "Undefined" floating strangely.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While fixing something in the font inspector (`npm run start`), I noticed that headlines following a section that only contains "Undefined" in the definition list were floating next to the word.
![image](https://user-images.githubusercontent.com/13076806/216560587-d5ff4d66-176a-4ecf-afbb-8776c210e1e6.png)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only affects the font inspector.

## Screenshots (if appropriate):
After the fix:
![image](https://user-images.githubusercontent.com/13076806/216560974-68004a48-e1db-486b-b748-b21bce95a9c8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
NOT APPLICABLE AS IT ONLY AFFECTS THE FONT INSPECTOR USED FOR TESTING
- [ ] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
