### PR TITLE
make jshint and jscs ignore the /.git folder

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
     "excludeFiles": [
+        ".git/**",
         "node_modules/**",
         "build/**",
         "dist/**",

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,4 @@
+/.git
 /bower_components
 /node_modules
 /dist


### PR DESCRIPTION
I noticed that that jscs showed messages about files in the /.git directory (e.g. WIP files from local branches), so I added it to the ignore lists of both jscs and jshint.