### PR TITLE
make cffEncoding.charset fall back to CIDs instead of undefined

### DIFF
--- a/src/tables/cff.js
+++ b/src/tables/cff.js
@@ -421,14 +421,14 @@ function parseCFFCharset(data, start, nGlyphs, strings) {
     if (format === 0) {
         for (let i = 0; i < nGlyphs; i += 1) {
             sid = parser.parseSID();
-            charset.push(getCFFString(strings, sid));
+            charset.push(getCFFString(strings, sid) || sid);
         }
     } else if (format === 1) {
         while (charset.length <= nGlyphs) {
             sid = parser.parseSID();
             count = parser.parseCard8();
             for (let i = 0; i <= count; i += 1) {
-                charset.push(getCFFString(strings, sid));
+                charset.push(getCFFString(strings, sid) || sid);
                 sid += 1;
             }
         }
@@ -437,7 +437,7 @@ function parseCFFCharset(data, start, nGlyphs, strings) {
             sid = parser.parseSID();
             count = parser.parseCard16();
             for (let i = 0; i <= count; i += 1) {
-                charset.push(getCFFString(strings, sid));
+                charset.push(getCFFString(strings, sid) || sid);
                 sid += 1;
             }
         }

--- a/test/tables/cff.js
+++ b/test/tables/cff.js
@@ -4,6 +4,7 @@ import Glyph from '../../src/glyph';
 import glyphset from '../../src/glyphset';
 import Path from '../../src/path';
 import cff from '../../src/tables/cff';
+import { load } from '../../src/opentype';
 
 describe('tables/cff.js', function () {
     const data =
@@ -39,6 +40,16 @@ describe('tables/cff.js', function () {
         const glyphs = new glyphset.GlyphSet(glyphSetFont, [nodefGlyph, bumpsGlyph]);
 
         assert.deepEqual(data, hex(cff.make(glyphs, options).encode()));
+    });
+
+    /**
+     * @see https://github.com/opentypejs/opentype.js/issues/524
+     */
+    it('can fall back to CIDs instead of strings when parsing the charset', function() {
+        load('./fonts/FiraSansOT-Medium.otf', (err, font) => {
+            assert.equal((new Set(font.cffEncoding.charset)).size, 1509);
+            assert.equal(font.cffEncoding.charset.includes(undefined), false);
+        }, {lowMemory: true});
     });
 
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
see #524

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #524

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Loaded *FiraSansOT-Medium.otf* before and after: former `undefined` entries are now the corresponding CID instead.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [X] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [X] I have read the **CONTRIBUTING** document.
