### PR TITLE
GSUB writing support for lookup type 5

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -197,12 +197,50 @@ function LookupList(lookupListTable, subtableMakers) {
 LookupList.prototype = Object.create(Table.prototype);
 LookupList.prototype.constructor = LookupList;
 
+/**
+ * @exports opentype.ClassDef
+ * @class
+ * @param {opentype.Table}
+ * @param {Object}
+ * @constructor
+ * @extends opentype.Table
+ *
+ * @see https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table
+ */
+function ClassDef(classDefTable) {
+    if (classDefTable.format === 1) {
+        Table.call(this, 'classDefTable',
+            [
+                {name: 'classFormat', type: 'USHORT', value: 1},
+                {name: 'startGlyphID', type: 'USHORT', value: classDefTable.startGlyph}
+            ]
+            .concat(ushortList('glyph', classDefTable.classes))
+        );
+    } else if (classDefTable.format === 2) {
+        Table.call(this, 'classDefTable',
+            [{name: 'classFormat', type: 'USHORT', value: 2}]
+            .concat(recordList('rangeRecord', classDefTable.ranges, function(RangeRecord, i) {
+                return [
+                    {name: 'startGlyphID' + i, type: 'USHORT', value: RangeRecord.start},
+                    {name: 'endGlyphID' + i, type: 'USHORT', value: RangeRecord.end},
+                    {name: 'class' + i, type: 'USHORT', value: RangeRecord.classId},
+                ];
+            }))
+        );
+    } else {
+        check.assert(false, 'Class format must be 1 or 2.');
+    }
+}
+ClassDef.prototype = Object.create(Table.prototype);
+ClassDef.prototype.constructor = ClassDef;
+
 // Record = same as Table, but inlined (a Table has an offset and its data is further in the stream)
 // Don't use offsets inside Records (probable bug), only in Tables.
 export default {
     Table,
     Record: Table,
     Coverage,
+    ClassDef,
     ScriptList,
     FeatureList,
     LookupList,

--- a/src/table.js
+++ b/src/table.js
@@ -12,10 +12,7 @@ import { encode, sizeOf } from './types';
  * @constructor
  */
 function Table(tableName, fields, options) {
-    // For coverage tables with coverage format 2, we do not want to add the coverage data directly to the table object,
-    // as this will result in wrong encoding order of the coverage data on serialization to bytes.
-    // The fallback of using the field values directly when not present on the table is handled in types.encode.TABLE() already.
-    if (fields.length && (fields[0].name !== 'coverageFormat' || fields[0].value === 1)) {
+    if (fields && fields.length) {
         for (let i = 0; i < fields.length; i += 1) {
             const field = fields[i];
             this[field.name] = field.value;
@@ -111,11 +108,11 @@ function Coverage(coverageTable) {
     } else if (coverageTable.format === 2) {
         Table.call(this, 'coverageTable',
             [{name: 'coverageFormat', type: 'USHORT', value: 2}]
-            .concat(recordList('rangeRecord', coverageTable.ranges, function(RangeRecord) {
+            .concat(recordList('rangeRecord', coverageTable.ranges, function(RangeRecord, i) {
                 return [
-                    {name: 'startGlyphID', type: 'USHORT', value: RangeRecord.start},
-                    {name: 'endGlyphID', type: 'USHORT', value: RangeRecord.end},
-                    {name: 'startCoverageIndex', type: 'USHORT', value: RangeRecord.index},
+                    {name: 'startGlyphID' + i, type: 'USHORT', value: RangeRecord.start},
+                    {name: 'endGlyphID' + i, type: 'USHORT', value: RangeRecord.end},
+                    {name: 'startCoverageIndex' + i, type: 'USHORT', value: RangeRecord.index},
                 ];
             }))
         );

--- a/src/tables/gsub.js
+++ b/src/tables/gsub.js
@@ -271,8 +271,8 @@ subtableMakers[5] = function makeLookup5(subtable) {
     } else if (subtable.substFormat === 2) {
         return new table.Table('contextualSubstitutionTable', [
             {name: 'substFormat', type: 'USHORT', value: subtable.substFormat},
-            {name: 'SetMarksHighCoverage', type: 'TABLE', value: new table.Coverage(subtable.coverage)},
-            {name: 'SetMarksHighClassDef', type: 'TABLE', value: new table.ClassDef(subtable.classDef)}
+            {name: 'coverage', type: 'TABLE', value: new table.Coverage(subtable.coverage)},
+            {name: 'classDef', type: 'TABLE', value: new table.ClassDef(subtable.classDef)}
         ].concat(table.tableList('classSeqRuleSet', subtable.classSets, function(classSeqRuleSet) {
             if (!classSeqRuleSet) {
                 return new table.Table('NULL', null);

--- a/src/tables/gsub.js
+++ b/src/tables/gsub.js
@@ -312,7 +312,25 @@ subtableMakers[5] = function makeLookup5(subtable) {
             }));
         })));
     } else if (subtable.substFormat === 3) {
-        check.assert(false, 'lookup type 5 format 3 is not yet supported.');
+        let tableData = [
+            {name: 'substFormat', type: 'USHORT', value: subtable.substFormat},
+        ];
+
+        tableData.push({name: 'inputGlyphCount', type: 'USHORT', value: subtable.coverages.length});
+        tableData.push({name: 'substitutionCount', type: 'USHORT', value: subtable.lookupRecords.length});
+        subtable.coverages.forEach((coverage, i) => {
+            tableData.push({name: 'inputCoverage' + i, type: 'TABLE', value: new table.Coverage(coverage)});
+        });
+
+        subtable.lookupRecords.forEach((record, i) => {
+            tableData = tableData
+                .concat({name: 'sequenceIndex' + i, type: 'USHORT', value: record.sequenceIndex})
+                .concat({name: 'lookupListIndex' + i, type: 'USHORT', value: record.lookupListIndex});
+        });
+
+        let returnTable = new table.Table('contextualSubstitutionTable', tableData);
+
+        return returnTable;
     }
 
     check.assert(false, 'lookup type 5 format must be 1, 2 or 3.');

--- a/src/tables/gsub.js
+++ b/src/tables/gsub.js
@@ -265,6 +265,37 @@ subtableMakers[4] = function makeLookup4(subtable) {
     })));
 };
 
+subtableMakers[5] = function makeLookup5(subtable) {
+    if (subtable.substFormat === 1) {
+        check.assert(false, 'lookup type 5 format 1 is not yet supported.');
+    } else if (subtable.substFormat === 2) {
+        return new table.Table('contextualSubstitutionTable', [
+            {name: 'substFormat', type: 'USHORT', value: subtable.substFormat},
+            {name: 'SetMarksHighCoverage', type: 'TABLE', value: new table.Coverage(subtable.coverage)},
+            {name: 'SetMarksHighClassDef', type: 'TABLE', value: new table.ClassDef(subtable.classDef)}
+        ].concat(table.tableList('classSeqRuleSet', subtable.classSets, function(classSeqRuleSet) {
+            if (!classSeqRuleSet) {
+                return new table.Table('NULL', null);
+            }
+            return new table.Table('classSeqRuleSetTable', table.tableList('classSeqRule', classSeqRuleSet, function(classSeqRule) {
+                let tableData = table.ushortList('classes', classSeqRule.classes, classSeqRule.classes.length + 1)
+                    .concat(table.ushortList('seqLookupCount', [], classSeqRule.lookupRecords.length));
+
+                classSeqRule.lookupRecords.forEach((record, i) => {
+                    tableData = tableData
+                        .concat({name: 'sequenceIndex' + i, type: 'USHORT', value: record.sequenceIndex})
+                        .concat({name: 'lookupListIndex' + i, type: 'USHORT', value: record.lookupListIndex});
+                });
+                return new table.Table('classSeqRuleTable', tableData);
+            }));
+        })));
+    } else if (subtable.substFormat === 3) {
+        check.assert(false, 'lookup type 5 format 3 is not yet supported.');
+    }
+
+    check.assert(false, 'lookup type 5 format must be 1, 2 or 3.');
+};
+
 subtableMakers[6] = function makeLookup6(subtable) {
     if (subtable.substFormat === 1) {
         let returnTable = new table.Table('chainContextTable', [

--- a/src/types.js
+++ b/src/types.js
@@ -972,7 +972,7 @@ encode.TABLE = function(table) {
  */
 sizeOf.TABLE = function(table) {
     let numBytes = 0;
-    const length = table.fields.length;
+    const length = (table.fields || []).length;
 
     for (let i = 0; i < length; i += 1) {
         const field = table.fields[i];

--- a/src/types.js
+++ b/src/types.js
@@ -921,7 +921,7 @@ sizeOf.OBJECT = function(v) {
  */
 encode.TABLE = function(table) {
     let d = [];
-    const length = table.fields.length;
+    const length = (table.fields || []).length;
     const subtables = [];
     const subtableOffsets = [];
 
@@ -937,9 +937,14 @@ encode.TABLE = function(table) {
         const bytes = encodingFunction(value);
 
         if (field.type === 'TABLE') {
-            subtableOffsets.push(d.length);
+            // If the table.fields are set to NULL, don't add it as subtable data,
+            // so the offset will be set to 0 but no table data will be added.
+            // This is required e.g. for classSeqRuleSetOffsets with no defined contexts.
+            if (value.fields !== null) {
+                subtableOffsets.push(d.length);
+                subtables.push(bytes);
+            }
             d.push(...[0, 0]);
-            subtables.push(bytes);
         } else {
             for (let j = 0; j < bytes.length; j++) {
                 d.push(bytes[j]);

--- a/test/table.js
+++ b/test/table.js
@@ -46,4 +46,37 @@ describe('table.js', function() {
             } },
         ]).encode(), expectedData);
     });
+
+    it('should make a ClassDefFormat1 table', function() {
+        // https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#example-7-classdefformat1-table-class-array
+        const expectedData = unhexArray(
+            '0001 0032 001A' +
+            '0000 0001 0000 0001 0000 0001 0002 0001 0000 0002 0001 0001 0000' +
+            '0000 0000 0002 0002 0000 0000 0001 0000 0000 0000 0000 0002 0001'
+        );
+        assert.deepEqual(new table.ClassDef({
+            format: 1,
+            startGlyph: 0x32,
+            classes: [
+                0, 1, 0, 1, 0, 1, 2, 1, 0, 2, 1, 1, 0,
+                0, 0, 2, 2, 0, 0, 1, 0, 0, 0, 0, 2, 1
+            ]
+        }).encode(), expectedData);
+    });
+
+    it('should make a ClassDefFormat2 table', function() {
+        // https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#example-8-classdefformat2-table-class-ranges
+        const expectedData = unhexArray(
+            '0002 0003 0030 0031 0002 0040 0041 0003 00D2 00D3 0001'
+        );
+
+        assert.deepEqual(new table.ClassDef({
+            format: 2,
+            ranges: [
+                { start: 0x30, end: 0x31, classId: 2 },
+                { start: 0x40, end: 0x41, classId: 3 },
+                { start: 0xd2, end: 0xd3, classId: 1 }
+            ]
+        }).encode(), expectedData);
+    });
 });

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -269,6 +269,8 @@ describe('tables/gsub.js', function() {
         });
     });
 
+    // FIXME: test lookup6 substFormat2 (we already support parsing it!)
+
     it('can parse lookup6 substFormat3', function() {
         // https://docs.microsoft.com/de-de/typography/opentype/spec/gsub#63-chaining-context-substitution-format-3-coverage-based-glyph-contexts
         // example taken from Inter Regular, with just offsets adapted to the structure when only creating the lookup

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -480,6 +480,28 @@ describe('tables/gsub.js', function() {
     // is already tested above
 
     //// Lookup type 5 ////////////////////////////////////////////////////////
+    it('can write lookup5 substFormat 1', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX7
+        const expectedData = unhexArray(
+            '0001 000A 0002 0012 0020' +                 // ContextSubstFormat1
+            '0001 0002 0028 005D' +                      // coverage format 1
+            '0001 0004 0002 0001 005D 0000 0001' +       // sub rule set "space and dash"
+            '0001 0004 0002 0001 0028 0001 0001'         // sub rule set "dash and space"
+        );
+
+        assert.deepEqual(makeLookup(5, {
+            substFormat: 1,
+            coverage: {
+                format: 1,
+                glyphs: [0x28, 0x5d]                                // space, dash
+            },
+            ruleSets: [
+                [{ input: [0x5d], lookupRecords: [{ sequenceIndex: 0, lookupListIndex: 1 }] }],
+                [{ input: [0x28], lookupRecords: [{ sequenceIndex: 1, lookupListIndex: 1 }] }]
+            ]
+        }));
+    });
+
     it('can write lookup5 substFormat2', function() {
         // https://learn.microsoft.com/en-gb/typography/opentype/spec/gsub#example-8-contextual-substitution-format-2
         const expectedData = unhexArray(
@@ -554,6 +576,35 @@ describe('tables/gsub.js', function() {
                 undefined,
                 [{ classes: [1], lookupRecords: [{ sequenceIndex: 1, lookupListIndex: 1 }] }],
                 [{ classes: [1], lookupRecords: [{ sequenceIndex: 1, lookupListIndex: 2 }] }]
+            ]
+        }), expectedData);
+    });
+
+    it('can write lookup5 substFormat 3', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX9
+        const expectedData = unhexArray(
+            '0003 0003 0002 0014 0030 0052 0000 0001 0002 0002' + // ContextSubstFormat3
+            '0001 000C 0033 0035 0037 0038 0039 003B 003C 003D 0041 0042 0045 004A' + // coverage format 1
+            '0001 000F 0032 0034 0036 003A 003E 003F 0040 0043 0044 0045 0046 0047 0048 0049 004B' + // coverage format 1
+            '0001 0005 0038 003B 0041 0042 004A' // coverage format 1
+        );
+        assert.deepEqual(makeLookup(5, {
+            substFormat: 3,
+            coverages: [{
+                    format: 1,
+                    glyphs: [0x33, 0x35, 0x37, 0x38, 0x39, 0x3b, 0x3c, 0x3d, 0x41, 0x42, 0x45, 0x4a]
+                },
+                {
+                    format: 1,
+                    glyphs: [0x32, 0x34, 0x36, 0x3a, 0x3e, 0x3f, 0x40, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4b]
+                },
+                {
+                    format: 1,
+                    glyphs: [0x38, 0x3b, 0x41, 0x42, 0x4a]
+                }],
+            lookupRecords: [
+                { sequenceIndex: 0, lookupListIndex: 1 },
+                { sequenceIndex: 2, lookupListIndex: 2 }
             ]
         }), expectedData);
     });

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -477,6 +477,85 @@ describe('tables/gsub.js', function() {
     //// Lookup type 4 ////////////////////////////////////////////////////////
     // is already tested above
 
+    //// Lookup type 5 ////////////////////////////////////////////////////////
+    it('can write lookup5 substFormat2', function() {
+        // https://learn.microsoft.com/en-gb/typography/opentype/spec/gsub#example-8-contextual-substitution-format-2
+        const expectedData = unhexArray(
+            // SequenceContextFormat2 SetMarksHighSubtable
+            '0002  0010  001C' + // substFormat, SetMarksHighCoverage, SetMarksHighClassDef
+            '0004' +             // classSeqRuleSetCount
+            '0000  0000  0032 0040' + // classSeqRuleSetOffsets[0]-[3]
+            // CoverageFormat1 SetMarksHighCoverage
+            '0001  0004' +       // coverageFormat: lists, glyphCount
+            '0030' +             // tahGlyphID: glyphArray[0], high base glyph
+            '0031' +             // dhahGlyphID: glyphArray[1], high base glyph
+            '0040' +             // cafGlyphID:	glyphArray[2], very high base glyph
+            '0041' +             // gafGlyphID: glyphArray[3], very high base glyph
+            // ClassDefFormat2 SetMarksHighClassDef
+            '0002  0003' +       // classFormat: ranges, classRangeCount
+            // classRangeRecords[0]:
+            // ClassRangeRecords ordered by startGlyphID; record for Class 2, high base glyphs
+            '0030' +             // tahGlyphID: Start, first Glyph ID in range
+            '0031' +             // dhahGlyphID: End, last Glyph ID in range
+            '0002' +             // class
+            // classRangeRecords[1]:
+            // ClassRangeRecord for Class 3, very high base glyphs
+            '0040' +             // cafGlyphID: Start, first Glyph ID in range
+            '0041' +             // gafGlyphID: End, last Glyph ID in range
+            '0003' +             // class (ClassRange[2] for Class 1, mark gyphs)            )
+            // classRangeRecords[2]:
+            // ClassRangeRecord for Class 1, mark glyphs
+            '00D2' +             // fathatanDefaultGlyphID: Start, first Glyph ID in range default fathatan mark
+            '00D3' +             // dammatanDefaultGlyphID: End, last Glyph ID in the range default dammatan mark
+            '0001' +             // class
+            // ClassSequencRuleSet SetMarksHighSubClassSet2
+            '0001' +             // classSeqRuleCount
+            '0004' +             // SetMarksHighSubClassRule2: classSeqRuleOffsets[0] (offset to ClassSequenceRule table 0) — ClassSequenceRule tables ordered by preference
+            // ClassSequenceRule SetMarksHighSubClassRule2:
+            // ClassSequenceRule[0] table definition, Class 2 glyph (high base) glyph followed by a Class 1 glyph (mark)
+            '0002' +             // glyphCount
+            '0001' +             // seqLookupCount
+            '0001' +             // inputSequence[0] — input sequence beginning with the second Class in the input context sequence; Class 1, mark glyphs
+            // seqLookupRecords[0]:
+            // seqLookupRecords array in design order
+            '0001' +             // sequenceIndex — apply substitution to position 2, a mark
+            '0001' +             // lookupListIndex
+            // ClassSequencRuleSet SetMarksVeryHighSubClassSet3:
+            // ClassSequencRuleSet[3] table definition — all contexts that begin with Class 3 glyphs
+            '0001' +             // classSeqRuleCount
+            '0004' +             // SetMarksVeryHighSubClassRule3: classSeqRuleOffsets[0]
+            // ClassSequenceRule: SetMarksVeryHighSubClassRule3
+            // ClassSequenceRule[0] table definition — Class 3 glyph (very high base glyph) followed by a Class 1 glyph (mark)
+            '0002' +             // glyphCount
+            '0001' +             // seqLookupCount
+            '0001' +             // inputSequence[0] — input sequence beginning with the second Class in the input context sequence; Class 1, mark glyphs
+            // seqLookupRecords[0]:	seqLookupRecords array in design order
+            '0001' +             // sequenceIndex — apply substitution to position 2, second glyph class (mark)
+            '0002'               // lookupListIndex
+        );
+        assert.deepEqual(makeLookup(5, {
+            substFormat: 2,
+            coverage: {
+                format: 1,
+                glyphs: [0x30, 0x31, 0x40, 0x41]
+            },
+            classDef: {
+                format: 2,
+                ranges: [
+                    { start: 0x30, end: 0x31, classId: 2 },
+                    { start: 0x40, end: 0x41, classId: 3 },
+                    { start: 0xD2, end: 0xD3, classId: 1 }
+                ]
+            },
+            classSets: [
+                undefined,
+                undefined,
+                [{ classes: [1], lookupRecords: [{ sequenceIndex: 1, lookupListIndex: 1 }] }],
+                [{ classes: [1], lookupRecords: [{ sequenceIndex: 1, lookupListIndex: 2 }] }]
+            ]
+        }), expectedData);
+    });
+
     //// Lookup type 6 ////////////////////////////////////////////////////////
     it('can write lookup6 substFormat1', function() {
         // https://docs.microsoft.com/de-de/typography/opentype/spec/gsub#lookuptype-6-chaining-contextual-substitution-subtable

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -480,8 +480,8 @@ describe('tables/gsub.js', function() {
     // is already tested above
 
     //// Lookup type 5 ////////////////////////////////////////////////////////
-    it('can write lookup5 substFormat 1', function() {
-        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX7
+    it('can write lookup5 substFormat1', function() {
+        // https://learn.microsoft.com/en-gb/typography/opentype/spec/gsub#example-7-contextual-substitution-format-1
         const expectedData = unhexArray(
             '0001 000A 0002 0012 0020' +                 // ContextSubstFormat1
             '0001 0002 0028 005D' +                      // coverage format 1
@@ -499,7 +499,7 @@ describe('tables/gsub.js', function() {
                 [{ input: [0x5d], lookupRecords: [{ sequenceIndex: 0, lookupListIndex: 1 }] }],
                 [{ input: [0x28], lookupRecords: [{ sequenceIndex: 1, lookupListIndex: 1 }] }]
             ]
-        }));
+        }), expectedData);
     });
 
     it('can write lookup5 substFormat2', function() {
@@ -580,7 +580,7 @@ describe('tables/gsub.js', function() {
         }), expectedData);
     });
 
-    it('can write lookup5 substFormat 3', function() {
+    it('can write lookup5 substFormat3', function() {
         // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX9
         const expectedData = unhexArray(
             '0003 0003 0002 0014 0030 0052 0000 0001 0002 0002' + // ContextSubstFormat3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Preliminary work
- [X] Fixed need for exceptional handling of coverageFormat2
- [X] Implemented NULL for table values (set offset to 0 without adding subtable data)
- [X] added new ClassDef type for writing support
* Writing support
- [X] SequenceContextFormat1
- [X] SequenceContextFormat2 
- [X] SequenceContextFormat3
* Tests
- [X] ClassDefFormat1
- [X] ClassDefFormat2
- [X] SequenceContextFormat1
- [X] SequenceContextFormat2 
- [X] SequenceContextFormat3

<s>Since Chaining Contextual Substitution is based on Contextual Substitution, I'll probably also add writing support for the last missing lookup type 6 format 2</s> Let's not make this more bloated than it already is and stick to one lookup type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Filling the gaps of the last missing GSUB lookup/format types

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests according to the Microsoft spec examples, checked to not break any preexisting tests, tested different fonts.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [X] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [X] I have read the **CONTRIBUTING** document.
