### PR TITLE
optimize performance by replacing modulus with bitwise operator

### DIFF
--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -1950,7 +1950,7 @@ function ODD(state) {
 
     if (exports.DEBUG) console.log(state.step, 'ODD[]', n);
 
-    stack.push(Math.trunc(n) % 2 ? 1 : 0);
+    stack.push(Math.trunc(n) & 1 ? 1 : 0);
 }
 
 // EVEN[] EVEN
@@ -1961,7 +1961,7 @@ function EVEN(state) {
 
     if (exports.DEBUG) console.log(state.step, 'EVEN[]', n);
 
-    stack.push(Math.trunc(n) % 2 ? 0 : 1);
+    stack.push(Math.trunc(n) & 1 ? 0 : 1);
 }
 
 // IF[] IF test

--- a/src/tables/cff.js
+++ b/src/tables/cff.js
@@ -527,7 +527,7 @@ function parseCFFCharstring(font, glyph, code) {
 
         // The number of stem operators on the stack is always even.
         // If the value is uneven, that means a width is specified.
-        hasWidthArg = stack.length % 2 !== 0;
+        hasWidthArg = (stack.length & 1) !== 0;
         if (hasWidthArg && !haveWidth) {
             width = stack.shift() + nominalWidthX;
         }
@@ -780,7 +780,7 @@ function parseCFFCharstring(font, glyph, code) {
                     p.curveTo(c1x, c1y, c2x, c2y, x, y);
                     break;
                 case 26: // vvcurveto
-                    if (stack.length % 2) {
+                    if (stack.length & 1) {
                         x += stack.shift();
                     }
 
@@ -796,7 +796,7 @@ function parseCFFCharstring(font, glyph, code) {
 
                     break;
                 case 27: // hhcurveto
-                    if (stack.length % 2) {
+                    if (stack.length & 1) {
                         y += stack.shift();
                     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaces all usage of modulus "% 2" with the bitwise AND operator "& 1"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Inspired by https://github.com/opentypejs/opentype.js/pull/569#discussion_r1114926698

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all tests (and asked ChatGPT if those statements are really interchangeable in JavaScript 😅)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Performance improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [X] I have read the **CONTRIBUTING** document.
