### PR TITLE
adding stringToGlyphIndexes()

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -174,16 +174,15 @@ Font.prototype.updateFeatures = function (options) {
 };
 
 /**
- * Convert the given text to a list of Glyph objects.
+ * Convert the given text to a list of Glyph indexes.
  * Note that there is no strict one-to-one mapping between characters and
- * glyphs, so the list of returned glyphs can be larger or smaller than the
+ * glyphs, so the list of returned glyph indexes can be larger or smaller than the
  * length of the given string.
  * @param  {string}
  * @param  {GlyphRenderOptions} [options]
- * @return {opentype.Glyph[]}
+ * @return {number[]}
  */
-Font.prototype.stringToGlyphs = function(s, options) {
-
+Font.prototype.stringToGlyphIndexes = function(s, options) {
     const bidi = new Bidi();
 
     // Create and register 'glyphIndex' state modifier
@@ -197,7 +196,20 @@ Font.prototype.stringToGlyphs = function(s, options) {
 
     bidi.applyFeatures(this, features);
 
-    const indexes = bidi.getTextGlyphs(s);
+    return bidi.getTextGlyphs(s);
+};
+
+/**
+ * Convert the given text to a list of Glyph objects.
+ * Note that there is no strict one-to-one mapping between characters and
+ * glyphs, so the list of returned glyphs can be larger or smaller than the
+ * length of the given string.
+ * @param  {string}
+ * @param  {GlyphRenderOptions} [options]
+ * @return {opentype.Glyph[]}
+ */
+Font.prototype.stringToGlyphs = function(s, options) {
+    const indexes = this.stringToGlyphIndexes(s, options);
 
     let length = indexes.length;
 

--- a/test/font.js
+++ b/test/font.js
@@ -15,6 +15,8 @@ describe('font.js', function() {
         fGlyph, iGlyph, ffGlyph, fiGlyph, ffiGlyph
     ];
 
+    glyphs.forEach((glyph, index) => glyph.index = index);
+
     beforeEach(function() {
         font = new Font({
             familyName: 'MyFont',
@@ -44,6 +46,20 @@ describe('font.js', function() {
         it('tables definition shall be serialized', function() {
             const os2 = font.toTables().tables.find(table => table.tableName === 'OS/2');
             assert.equal(os2.achVendID, 'TEST');
+        });
+    });
+
+    describe('stringToGlyphIndexes', function() {
+        it('must support standard ligatures', function() {
+            assert.deepEqual(font.stringToGlyphIndexes('fi'), [fGlyph.index, iGlyph.index]);
+            font.substitution.add('liga', { sub: [1, 1, 2], by: 5 });
+            font.substitution.add('liga', { sub: [1, 1], by: 3 });
+            font.substitution.add('liga', { sub: [1, 2], by: 4 });
+            assert.deepEqual(font.stringToGlyphIndexes('ff'), [ffGlyph.index]);
+            assert.deepEqual(font.stringToGlyphIndexes('fi'), [fiGlyph.index]);
+            assert.deepEqual(font.stringToGlyphIndexes('ffi'), [ffiGlyph.index]);
+            assert.deepEqual(font.stringToGlyphIndexes('fffiffif'),
+                [ffGlyph.index, fiGlyph.index, ffiGlyph.index, fGlyph.index]);
         });
     });
 


### PR DESCRIPTION
## Description
adresses #574 

## How Has This Been Tested?
I tested it with my quite larger app, it works, it's quite a trivial change tough.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes. 
No I didn't, I tested it with my application.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
charToGlyphIndex() and nameToGlyphIndex() are also not mentenioned in the README, maybe we should add all?
- [x] I have read the **CONTRIBUTING** document.
