### PR TITLE
Parsing and writing support for variable font tables fvar, STAT and avar

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -550,6 +550,7 @@ Parser.uShort = Parser.offset16 = Parser.prototype.parseUShort;
 Parser.uShortList = Parser.prototype.parseUShortList;
 Parser.uLong = Parser.offset32 = Parser.prototype.parseULong;
 Parser.uLongList = Parser.prototype.parseULongList;
+Parser.fixed = Parser.prototype.parseFixed;
 Parser.struct = Parser.prototype.parseStruct;
 Parser.coverage = Parser.prototype.parseCoverage;
 Parser.classDef = Parser.prototype.parseClassDef;

--- a/src/substitution.js
+++ b/src/substitution.js
@@ -3,6 +3,7 @@
 
 import check from './check.js';
 import Layout from './layout.js';
+import { arraysEqual } from './util.js';
 
 /**
  * @exports opentype.Substitution
@@ -13,16 +14,6 @@ import Layout from './layout.js';
  */
 function Substitution(font) {
     Layout.call(this, font, 'gsub');
-}
-
-// Check if 2 arrays of primitives are equal.
-function arraysEqual(ar1, ar2) {
-    const n = ar1.length;
-    if (n !== ar2.length) { return false; }
-    for (let i = 0; i < n; i++) {
-        if (ar1[i] !== ar2[i]) { return false; }
-    }
-    return true;
 }
 
 // Find the first subtable of a lookup table in a particular format.

--- a/src/tables/avar.js
+++ b/src/tables/avar.js
@@ -1,0 +1,90 @@
+// The `avar` table stores information on how to modify a variation along a variation axis
+// https://learn.microsoft.com/en-us/typography/opentype/spec/avar
+
+import check from '../check.js';
+import { Parser } from '../parse.js';
+import table from '../table.js';
+
+function makeAvarAxisValueMap(n, axisValueMap) {
+    return new table.Record('axisValueMap_' + n, [
+        {name: 'fromCoordinate_' + n, type: 'F2DOT14', value: axisValueMap.fromCoordinate},
+        {name: 'toCoordinate_' + n, type: 'F2DOT14', value: axisValueMap.toCoordinate}
+    ]);
+}
+
+function makeAvarSegmentMap(n, axis) {
+    const returnTable = new table.Record('segmentMap_' + n, [
+        {name: 'positionMapCount_' + n, type: 'USHORT', value: axis.axisValueMaps.length}
+    ]);
+
+    let axisValueMaps = [];
+    for (let i = 0; i < axis.axisValueMaps.length; i++) {
+        const valueMap = makeAvarAxisValueMap(`${n}_${i}`, axis.axisValueMaps[i]);
+        axisValueMaps = axisValueMaps.concat(valueMap.fields);
+    }
+
+    returnTable.fields = returnTable.fields.concat(axisValueMaps);
+
+    return returnTable;
+}
+
+function makeAvarTable(avar, fvar) {
+    check.argument(avar.axisSegmentMaps.length === fvar.axes.length, 'avar axis count must correspond to fvar axis count');
+
+    const result = new table.Table('avar', [
+        {name: 'majorVersion', type: 'USHORT', value: 1},
+        {name: 'minorVersion', type: 'USHORT', value: 0},
+        {name: 'reserved', type: 'USHORT', value: 0},
+        {name: 'axisCount', type: 'USHORT', value: avar.axisSegmentMaps.length},
+    ]);
+
+    for (let i = 0; i < avar.axisSegmentMaps.length; i++) {
+        const axisRecord = makeAvarSegmentMap(i, avar.axisSegmentMaps[i]);
+        result.fields = result.fields.concat(axisRecord.fields);
+    }
+
+    return result;
+}
+
+function parseAvarTable(data, start, fvar) {
+    if (!start) {
+        start = 0;
+    }
+
+    const p = new Parser(data, start);
+    const tableVersionMajor = p.parseUShort();
+    const tableVersionMinor = p.parseUShort();
+
+    if (tableVersionMajor !== 1) {
+        console.warn(`Unsupported avar table version ${tableVersionMajor}.${tableVersionMinor}`);
+    }
+
+    p.skip('uShort', 1); // reserved
+    const axisCount = p.parseUShort();
+
+    check.argument(axisCount === fvar.axes.length, 'avar axis count must correspond to fvar axis count');
+
+    const axisSegmentMaps = [];
+    for (let i = 0; i < axisCount; i++) {
+        const axisValueMaps = [];
+        const positionMapCount = p.parseUShort();
+        for (let j = 0; j < positionMapCount; j++) {
+            const fromCoordinate = p.parseF2Dot14();
+            const toCoordinate = p.parseF2Dot14();
+            axisValueMaps.push({
+                fromCoordinate,
+                toCoordinate
+            });
+        }
+        axisSegmentMaps.push({
+            axisValueMaps
+        });
+    }
+
+    return {
+        version: [tableVersionMajor, tableVersionMinor],
+        axisSegmentMaps
+    };
+}
+
+export default { make: makeAvarTable, parse: parseAvarTable };

--- a/src/tables/fvar.js
+++ b/src/tables/fvar.js
@@ -4,26 +4,28 @@
 import check from '../check.js';
 import parse from '../parse.js';
 import table from '../table.js';
+import { objectsEqual } from '../util.js';
 
 function addName(name, names) {
-    const nameString = JSON.stringify(name);
     let nameID = 256;
-    for (let nameKey in names) {
-        let n = parseInt(nameKey);
-        if (!n || n < 256) {
-            continue;
-        }
+    for (let platform in names) {
+        for (let nameKey in names[platform]) {
+            let n = parseInt(nameKey);
+            if (!n || n < 256) {
+                continue;
+            }
 
-        if (JSON.stringify(names[nameKey]) === nameString) {
-            return n;
-        }
+            if (objectsEqual(names[platform][nameKey], name)) {
+                return n;
+            }
 
-        if (nameID <= n) {
-            nameID = n + 1;
+            if (nameID <= n) {
+                nameID = n + 1;
+            }
         }
+        names[platform][nameID] = name;
     }
 
-    names[nameID] = name;
     return nameID;
 }
 
@@ -47,7 +49,7 @@ function parseFvarAxis(data, start, names) {
     axis.defaultValue = p.parseFixed();
     axis.maxValue = p.parseFixed();
     p.skip('uShort', 1);  // reserved for flags; no values defined
-    axis.name = names[p.parseUShort()] || {};
+    axis.name = (names.macintosh || names.windows || names.unicode)[p.parseUShort()] || {};
     return axis;
 }
 
@@ -73,7 +75,7 @@ function makeFvarInstance(n, inst, axes, names) {
 function parseFvarInstance(data, start, axes, names) {
     const inst = {};
     const p = new parse.Parser(data, start);
-    inst.name = names[p.parseUShort()] || {};
+    inst.name = (names.macintosh || names.windows || names.unicode)[p.parseUShort()] || {};
     p.skip('uShort', 1);  // reserved for flags; no values defined
 
     inst.coordinates = {};

--- a/src/tables/gvar.js
+++ b/src/tables/gvar.js
@@ -1,0 +1,16 @@
+// The `gvar` table stores information on how to modify glyf outlines across the variation space
+// https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
+
+// import check from '../check';
+// import parse from '../parse';
+// import table from '../table';
+
+function makeGvarTable() {
+    console.warn('Writing of gvar tables is not yet supported.');
+}
+
+function parseGvarTable(/*data, start, names*/) {
+    console.warn('Parsing of gvar tables is not yet supported.');
+}
+
+export default { make: makeGvarTable, parse: parseGvarTable };

--- a/src/tables/stat.js
+++ b/src/tables/stat.js
@@ -1,0 +1,249 @@
+// The `STAT` table stores information on design attributes for font-style variants
+// https://learn.microsoft.com/en-us/typography/opentype/spec/STAT
+
+import check from '../check.js';
+import { default as parse, Parser } from '../parse.js';
+import table from '../table.js';
+
+const axisRecordStruct = {
+    tag: Parser.tag,
+    nameID: Parser.uShort,
+    ordering: Parser.uShort
+};
+
+const axisValueParsers = new Array(5);
+
+// https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/STAT_delta#axis-value-table-format-1
+axisValueParsers[1] = function axisValueParser1() {
+    return {
+        axisIndex: this.parseUShort(),
+        flags: this.parseUShort(),
+        valueNameID: this.parseUShort(),
+        value: this.parseFixed()
+    };
+};
+
+// https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/STAT_delta#axis-value-table-format-2
+axisValueParsers[2] = function axisValueParser2() {
+    return {
+        axisIndex: this.parseUShort(),
+        flags: this.parseUShort(),
+        valueNameID: this.parseUShort(),
+        nominalValue: this.parseFixed(),
+        rangeMinValue: this.parseFixed(),
+        rangeMaxValue: this.parseFixed()
+    };
+};
+
+// https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/STAT_delta#axis-value-table-format-3
+axisValueParsers[3] = function axisValueParser3() {
+    return {
+        axisIndex: this.parseUShort(),
+        flags: this.parseUShort(),
+        valueNameID: this.parseUShort(),
+        value: this.parseFixed(),
+        linkedValue: this.parseFixed()
+    };
+
+};
+
+// https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/STAT_delta#axis-value-table-format-4
+axisValueParsers[4] = function axisValueParser4() {
+    const axisCount = this.parseUShort();
+    return {
+        flags: this.parseUShort(),
+        valueNameID: this.parseUShort(),
+        axisValues: this.parseList(axisCount, function() {
+            return {
+                axisIndex: this.parseUShort(),
+                value: this.parseFixed()
+            };
+        })
+    };
+};
+
+function parseSTATAxisValue() {
+    const valueTableFormat = this.parseUShort();
+    const axisValueParser = axisValueParsers[valueTableFormat];
+    const formatStub = {
+        format: valueTableFormat
+    };
+    if (axisValueParser === undefined) {
+        console.warn(`Unknown axis value table format ${valueTableFormat}`);
+        return formatStub;
+    }
+    return Object.assign(formatStub, this.parseStruct(axisValueParser.bind(this)));
+}
+
+function parseSTATTable(data, start, fvar) {
+    if (!start) {
+        start = 0;
+    }
+
+    const p = new parse.Parser(data, start);
+    const tableVersionMajor = p.parseUShort();
+    const tableVersionMinor = p.parseUShort();
+
+    if (tableVersionMajor !== 1) {
+        console.warn(`Unsupported STAT table version ${tableVersionMajor}.${tableVersionMinor}`);
+    }
+    const version = [
+        tableVersionMajor, tableVersionMinor
+    ];
+
+    const designAxisSize = p.parseUShort();
+    const designAxisCount = p.parseUShort();
+    const designAxesOffset = p.parseOffset32();
+    const axisValueCount = p.parseUShort();
+    const offsetToAxisValueOffsets = p.parseOffset32();
+    const elidedFallbackNameID = (tableVersionMajor > 1 || tableVersionMinor > 0) ? p.parseUShort() : undefined;
+
+    if (fvar !== undefined) {
+        check.argument(designAxisCount >= fvar.axes.length, 'STAT axis count must be greater than or equal to fvar axis count');
+    }
+
+    if (axisValueCount > 0) {
+        check.argument(designAxisCount >= 0, 'STAT axis count must be greater than 0 if STAT axis value count is greater than 0');
+    }
+
+    const axes = [];
+    for (let i = 0; i < designAxisCount; i++) {
+        p.offset = start + designAxesOffset;
+        p.relativeOffset = i * designAxisSize;
+        axes.push(p.parseStruct(axisRecordStruct));
+    }
+
+    p.offset = start;
+    p.relativeOffset = offsetToAxisValueOffsets;
+
+    const valueOffsets = p.parseUShortList(axisValueCount);
+    const values = [];
+    for (let i = 0; i < axisValueCount; i++) {
+        p.offset = start + offsetToAxisValueOffsets;
+        p.relativeOffset = valueOffsets[i];
+        values.push(parseSTATAxisValue.apply(p));
+    }
+
+    return {
+        version,
+        axes,
+        values,
+        elidedFallbackNameID
+    };
+}
+
+const axisValueMakers = new Array(5);
+
+// https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/STAT_delta#axis-value-table-format-1
+axisValueMakers[1] = function axisValueMaker1(n, table) {
+    return [
+        {name: `format${n}`, type: 'USHORT', value: 1},
+        {name: `axisIndex${n}`, type: 'USHORT', value: table.axisIndex},
+        {name: `flags${n}`, type: 'USHORT', value: table.flags},
+        {name: `valueNameID${n}`, type: 'USHORT', value: table.valueNameID},
+        {name: `value${n}`, type: 'FLOAT', value: table.value}
+    ];
+};
+
+// https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/STAT_delta#axis-value-table-format-2
+axisValueMakers[2] = function axisValueMaker2(n, table) {
+    return [
+        {name: `format${n}`, type: 'USHORT', value: 2},
+        {name: `axisIndex${n}`, type: 'USHORT', value: table.axisIndex},
+        {name: `flags${n}`, type: 'USHORT', value: table.flags},
+        {name: `valueNameID${n}`, type: 'USHORT', value: table.valueNameID},
+        {name: `nominalValue${n}`, type: 'FLOAT', value: table.nominalValue},
+        {name: `rangeMinValue${n}`, type: 'FLOAT', value: table.rangeMinValue},
+        {name: `rangeMaxValue${n}`, type: 'FLOAT', value: table.rangeMaxValue}
+    ];
+};
+
+// https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/STAT_delta#axis-value-table-format-3
+axisValueMakers[3] = function axisValueMaker3(n, table) {
+    return [
+        {name: `format${n}`, type: 'USHORT', value: 3},
+        {name: `axisIndex${n}`, type: 'USHORT', value: table.axisIndex},
+        {name: `flags${n}`, type: 'USHORT', value: table.flags},
+        {name: `valueNameID${n}`, type: 'USHORT', value: table.valueNameID},
+        {name: `value${n}`, type: 'FLOAT', value: table.value},
+        {name: `linkedValue${n}`, type: 'FLOAT', value: table.linkedValue}
+    ];
+};
+
+// https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/STAT_delta#axis-value-table-format-4
+axisValueMakers[4] = function axisValueMaker4(n, table) {
+    let returnFields = [
+        {name: `format${n}`, type: 'USHORT', value: 4},
+        {name: `axisCount${n}`, type: 'USHORT', value: table.axisValues.length},
+        {name: `flags${n}`, type: 'USHORT', value: table.flags},
+        {name: `valueNameID${n}`, type: 'USHORT', value: table.valueNameID}
+    ];
+
+    for (let i = 0; i < table.axisValues.length; i++) {
+        returnFields = returnFields.concat([
+            {name: `format${n}axisIndex${i}`, type: 'USHORT', value: table.axisValues[i].axisIndex},
+            {name: `format${n}value${i}`, type: 'FLOAT', value: table.axisValues[i].value},
+        ]);
+    }
+
+    return returnFields;
+};
+
+function makeSTATAxisRecord(n, axis) {
+    return new table.Record('axisRecord_' + n, [
+        {name: 'axisTag_' + n, type: 'TAG', value: axis.tag},
+        {name: 'axisNameID_' + n, type: 'USHORT', value: axis.nameID},
+        {name: 'axisOrdering_' + n, type: 'USHORT', value: axis.ordering}
+    ]);
+}
+
+function makeSTATValueTable(n, tableData) {
+    const valueTableFormat = tableData.format;
+    const axisValueMaker = axisValueMakers[valueTableFormat];
+    check.argument(axisValueMaker !== undefined, `Unknown axis value table format ${valueTableFormat}`);
+    const fields = axisValueMaker(n, tableData);
+    return new table.Table('axisValueTable_' + n, fields);
+}
+
+function makeSTATTable(STAT) {
+    const result = new table.Table('STAT', [
+        {name: 'majorVersion', type: 'USHORT', value: 1},
+        {name: 'minorVersion', type: 'USHORT', value: 2},
+        {name: 'designAxisSize', type: 'USHORT', value: 8},
+        {name: 'designAxisCount', type: 'USHORT', value: STAT.axes.length},
+        {name: 'designAxesOffset', type: 'ULONG', value: 0},
+        {name: 'axisValueCount', type: 'USHORT', value: STAT.values.length},
+        {name: 'offsetToAxisValueOffsets', type: 'ULONG', value: 0},
+        {name: 'elidedFallbackNameID', type: 'USHORT', value: STAT.elidedFallbackNameID},
+    ]);
+
+    result.designAxesOffset = result.offsetToAxisValueOffsets = result.sizeOf();
+
+    for (let i = 0; i < STAT.axes.length; i++) {
+        const axisRecord = makeSTATAxisRecord(i, STAT.axes[i]);
+        result.offsetToAxisValueOffsets += axisRecord.sizeOf();
+        result.fields = result.fields.concat(axisRecord.fields);
+    }
+
+    const axisValueOffsets = [];
+    let axisValueTables = [];
+    let axisValueTableOffset = STAT.values.length * 2; // size of the offset array
+
+    for (let j = 0; j < STAT.values.length; j++) {
+        const axisValueTable = makeSTATValueTable(j, STAT.values[j]);
+        axisValueOffsets.push({
+            name: 'offset_' + j,
+            type: 'USHORT',
+            value: axisValueTableOffset
+        });
+        axisValueTableOffset += axisValueTable.sizeOf();
+        axisValueTables = axisValueTables.concat(axisValueTable.fields);
+    }
+
+    result.fields = result.fields.concat(axisValueOffsets);
+    result.fields = result.fields.concat(axisValueTables);
+
+    return result;
+}
+
+export default { make: makeSTATTable, parse: parseSTATTable };

--- a/src/util.js
+++ b/src/util.js
@@ -12,4 +12,24 @@ function checkArgument(expression, message) {
     }
 }
 
-export { isBrowser, isNode, checkArgument };
+// Check if 2 arrays of primitives are equal.
+function arraysEqual(ar1, ar2) {
+    const n = ar1.length;
+    if (n !== ar2.length) { return false; }
+    for (let i = 0; i < n; i++) {
+        if (ar1[i] !== ar2[i]) { return false; }
+    }
+    return true;
+}
+
+// Check if 2 objects are equal
+function objectsEqual(obj1, obj2) {
+    const val1 = Object.values(obj1);
+    const val2 = Object.values(obj2);
+    const keys1 = Object.values(obj1);
+    const keys2 = Object.values(obj2);
+
+    return arraysEqual(val1, val2) && arraysEqual(keys1, keys2);
+}
+
+export { isBrowser, isNode, checkArgument, arraysEqual, objectsEqual };

--- a/test/tables/avar.js
+++ b/test/tables/avar.js
@@ -1,0 +1,57 @@
+import assert from 'assert';
+import { hex, unhex } from '../testutil';
+import avar from '../../src/tables/avar';
+
+describe('tables/avar.js', function() {
+    const fvar = {axes: [
+        {tag: 'TEST', minValue: 100, defaultValue: 400, maxValue: 900, name: {en: 'Test'}},
+        {tag: 'TEST2', minValue: 0, defaultValue: 1, maxValue: 2, name: {en: 'Test2'}}
+    ]};
+
+    const data =
+        // version
+        '00 01 00 00 ' +
+        // reserved, axisCount
+        '00 00 00 02 ' +
+        // positionMapCount
+        '00 05 ' +
+        // axisValueMaps
+        'C0 00 C0 00 ' +
+        'E0 00 00 00 ' +
+        '00 00 00 00 ' +
+        '20 00 00 00 ' +
+        '40 00 40 00 ' +
+        // positionMapCount 2
+        '00 03 ' +
+        // axisValueMaps 2
+        'C0 00 C0 00 ' +
+        '00 00 00 00 ' +
+        '40 00 40 00';
+
+    const table = {
+        version: [1, 0],
+        axisSegmentMaps: [
+            {axisValueMaps: [
+                {fromCoordinate: -1, toCoordinate: -1},
+                {fromCoordinate: -0.5, toCoordinate: 0},
+                {fromCoordinate: 0, toCoordinate: 0},
+                {fromCoordinate: 0.5, toCoordinate: 0},
+                {fromCoordinate: 1, toCoordinate: 1}
+            ]},
+            {axisValueMaps: [
+                {fromCoordinate: -1, toCoordinate: -1},
+                {fromCoordinate: 0, toCoordinate: 0},
+                {fromCoordinate: 1, toCoordinate: 1}
+            ]}
+        ]
+    };
+
+    it('can parse an axis variation table', function() {
+        assert.deepEqual(avar.parse(unhex(data), 0, fvar), table);
+    });
+
+    it('can make an axis variation table', function() {
+        const encodedTable = avar.make(table, fvar).encode();
+        assert.deepEqual(hex(encodedTable), data);
+    });
+});

--- a/test/tables/fvar.js
+++ b/test/tables/fvar.js
@@ -41,35 +41,41 @@ describe('tables/fvar.js', function() {
 
     it('can parse a font variations table', function() {
         const names = {
-            257: {en: 'Weight', ja: 'ウエイト'},
-            258: {en: 'Width', ja: '幅'},
-            259: {en: 'Regular', ja: 'レギュラー'},
-            260: {en: 'Condensed', ja: 'コンデンス'}
+            macintosh: {
+                257: {en: 'Weight', ja: 'ウエイト'},
+                258: {en: 'Width', ja: '幅'},
+                259: {en: 'Regular', ja: 'レギュラー'},
+                260: {en: 'Condensed', ja: 'コンデンス'}
+            }
         };
         assert.deepEqual(table, fvar.parse(unhex(data), 0, names));
     });
 
     it('can make a font variations table', function() {
         const names = {
-            // When assigning name IDs, numbers below 256 should be ignored,
-            // as these are not valid IDs of ‘fvar’ axis or instance names.
-            111: {en: 'Name #111'},
+            macintosh: {
+                // When assigning name IDs, numbers below 256 should be ignored,
+                // as these are not valid IDs of ‘fvar’ axis or instance names.
+                111: {en: 'Name #111'},
 
-            // Existing names with ID 256 or higher should be left untouched,
-            // as these can be valid names of font features.
-            256: {en: 'Ligatures', ja: 'リガチャ'},
+                // Existing names with ID 256 or higher should be left untouched,
+                // as these can be valid names of font features.
+                256: {en: 'Ligatures', ja: 'リガチャ'},
 
-            // Existing names with ID 256 or higher should be re-used.
-            257: {en: 'Weight', ja: 'ウエイト'}
+                // Existing names with ID 256 or higher should be re-used.
+                257: {en: 'Weight', ja: 'ウエイト'}
+            }
         };
         assert.deepEqual(data, hex(fvar.make(table, names).encode()));
         assert.deepEqual(names, {
-            111: {en: 'Name #111'},
-            256: {en: 'Ligatures', ja: 'リガチャ'},
-            257: {en: 'Weight', ja: 'ウエイト'},
-            258: {en: 'Width', ja: '幅'},
-            259: {en: 'Regular', ja: 'レギュラー'},
-            260: {en: 'Condensed', ja: 'コンデンス'}
+            macintosh: {
+                111: {en: 'Name #111'},
+                256: {en: 'Ligatures', ja: 'リガチャ'},
+                257: {en: 'Weight', ja: 'ウエイト'},
+                258: {en: 'Width', ja: '幅'},
+                259: {en: 'Regular', ja: 'レギュラー'},
+                260: {en: 'Condensed', ja: 'コンデンス'}
+            }
         });
     });
 });

--- a/test/tables/stat.js
+++ b/test/tables/stat.js
@@ -1,0 +1,69 @@
+import assert from 'assert';
+import { hex, unhex } from '../testutil';
+import STAT from '../../src/tables/stat';
+
+describe('tables/stat.js', function() {
+    // Style Attributes Header, v1.2
+    const h10 = '00 01 00 00 00 08 00 03 00 00 00 12 00 04 00 00 00 2A';
+    // Style Attributes Header, v1.0
+    const h12 = '00 01 00 02 00 08 00 03 00 00 00 14 00 04 00 00 00 2C 12 F0';
+
+    const data =
+        // "wght" Axis Record
+        '77 67 68 74 01 23 00 01 ' +
+        // "ital" Axis Record
+        '69 74 61 6C 01 01 00 03 ' +
+        // "opsz" Axis Record
+        '6F 70 73 7A 00 48 00 02 ' +
+        // axisValueOffsets
+        '00 08 00 14 00 28 00 38 ' +
+        // Axis value table, format 1
+        '00 01 00 01 00 02 00 78 01 23 45 67 ' +
+        // Axis value table, format 2
+        '00 02 00 02 00 01 00 96 00 18 00 00 00 02 00 00 7F FF 00 00 ' +
+        // Axis value table, format 3
+        '00 03 00 01 00 02 00 FC 00 01 23 00 00 45 67 89 ' +
+        // Axis value table, format 4
+        '00 04 00 02 00 01 01 48 ' +
+        '00 02 80 00 00 00 ' +
+        '00 00 01 A4 00 00';
+
+    const table = {
+        version: [1, 0],
+        axes: [
+            { tag: 'wght', nameID: 291, ordering: 1 },
+            { tag: 'ital', nameID: 257, ordering: 3 },
+            { tag: 'opsz', nameID: 72, ordering: 2 }
+        ],
+        values: [
+            { format: 1, axisIndex: 1, flags: 2, valueNameID: 120, value: 291.2711070420386 },
+            { format: 2, axisIndex: 2, flags: 1, valueNameID: 150, nominalValue: 24, rangeMinValue: 2, rangeMaxValue: 32767 },
+            { format: 3, axisIndex: 1, flags: 2, valueNameID: 252, value: 1.1367208361944, linkedValue: 69.40444037537193 },
+            { format: 4, flags: 1, valueNameID: 328, axisValues: [
+                { axisIndex: 2, value: -32768 },
+                { axisIndex: 0, value: 420 }
+            ] }
+        ],
+        elidedFallbackNameID: undefined
+    };
+
+    it('can parse a font variations table v1.0', function() {
+        assert.deepEqual(STAT.parse(unhex(h10 + data)), table);
+    });
+
+    // v1.1 and v1.2 headers are identical,
+    // v1.2 only added support for value table format 4
+
+    it('can parse a font variations table v1.2', function() {
+        table.version[1] = 2;
+        table.elidedFallbackNameID = 4848;
+        assert.deepEqual(STAT.parse(unhex(h12 + data)), table);
+    });
+
+    it('can make a font variations table', function() {
+        table.version[1] = 2;
+        table.elidedFallbackNameID = 4848;
+        const encodedTable = STAT.make(table).encode();
+        assert.deepEqual(hex(encodedTable), h12 + ' ' + data);
+    });
+});

--- a/test/types.js
+++ b/test/types.js
@@ -53,6 +53,23 @@ describe('types.js', function() {
         assert.equal(sizeOf.FIXED(0xBEEFCAFE), 4);
     });
 
+    it('can handle FLOAT', function() {
+        assert.equal(hex(encode.FLOAT(123.456)), '00 7B 74 BC');
+        assert.equal(sizeOf.FLOAT(123.456), 4);
+        assert.equal(hex(encode.FLOAT(-123.456)), 'FF 84 8B 44');
+        assert.equal(sizeOf.FLOAT(-123.456), 4);
+    });
+
+    it('handles the range guard for FLOAT (16.16) representation', function() {
+        const MIN_16_16 = -(1 << 15);
+        const MAX_16_16 = (1 << 15) - 1 + (1 / (1 << 16));
+        const error = /outside the range/;
+        assert.doesNotThrow(function() {encode.FLOAT(MIN_16_16);}, error);
+        assert.doesNotThrow(function() {encode.FLOAT(MAX_16_16);}, error);
+        assert.throws(function() {encode.FLOAT(MIN_16_16 - 0.001);}, error);
+        assert.throws(function() {encode.FLOAT(MAX_16_16 + 0.001);}, error);
+    });
+
     it('can handle FWORD', function() {
         assert.equal(hex(encode.FWORD(-8193)), 'DF FF');
         assert.equal(sizeOf.FWORD(-8193), 2);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- [X] add missing `encode.F2DOT14`
- [X] add `encode.FLOAT` as a wrapper to `encode.FIXED` when handling actual float numbers
- [X] adapt `fvar` writing to new platform-agnostic names structure (see #542)
- [X] fix `fvar` table not being written (fix #573)
- [X] add parsing and writing support for `STAT`
- [X] add parsing and writing support for `avar`
- [X] add stub for gvar parsing and writing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR lays the groundwork for variable fonts support. Actual coordinate scaling and normalization (see https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#CSN) for rendering is not yet implemented, but several tables needed for supporting it can now be parsed and written.

I decided against also implementing `gvar`, because it introduces a set of new concepts/data types and seems to be the most complex of them. That would have bloated the PR even more.

### Further resources for future rendering implementation:
* arrowtype/blog/issues/6
* https://www.axis-praxis.org/samsa/

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Loading and saving different variable fonts, added tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [X] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [X] I have read the **CONTRIBUTING** document.
