### PR TITLE
fix: add missing `type` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "type": "git",
     "url": "git://github.com/opentypejs/opentype.js.git"
   },
+  "type": "module",
   "main": "./dist/opentype.js",
   "browser": "./dist/opentype.js",
   "module": "./dist/opentype.module.js",


### PR DESCRIPTION
## Description
added `"type": "module"` to `package.json`

I'm not 100% certain this won't cause problems with legacy CJS builds / pipelines because I've always used ESM exclusively, but out of the dozens of dependencies in my project, this is the only one that causes this error.  I'm hoping to at least open a discussion about this with some of you who are very experienced with both CJS and ESM so I can learn more about how to navigate / assist in this predicament.

## Motivation and Context
This fixes the following errors when consuming `opentype`:
```bash
(node:4803) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
..../node_modules/.pnpm/opentype.js@1.3.4/node_modules/opentype.js/dist/opentype.module.js:14458
export default opentype;
^^^^^^

SyntaxError: Unexpected token 'export'
    at compileFunction (<anonymous>)
```

## How Has This Been Tested?
No additional tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.