### PR TITLE
fix reading-writing.thml

### DIFF
--- a/docs/examples/reading-writing.html
+++ b/docs/examples/reading-writing.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>OpenType writing</title>
-    <script src="/dist/opentype.js"></script>
+    <script src="https://opentype.js.org/dist/opentype.js"></script>
     <style>
         body {
             font: 13px Helvetica, arial, freesans, sans-serif;
@@ -60,14 +60,14 @@
         return ctx;
     }
 
-    opentype.load('../fonts/FiraSansOT-Medium.otf', function (err, font) {
+    opentype.load('../fonts/FiraSansMedium.woff', function (err, font) {
         if (err) {
             console.log(err);
         }
         inFont = font;
         var buffer = inFont.toArrayBuffer();
         outFont = opentype.parse(buffer);
-        document.getElementById('fontFamilyName').innerHTML = outFont.names.fontFamily.en;
+        document.getElementById('fontFamilyName').innerHTML = outFont.names.windows.fontFamily.en;
 
         for (var i = 0; i < outFont.glyphs.length; i++) {
             var glyph = outFont.glyphs.get(i);


### PR DESCRIPTION
## Description
Fixed some path to missing font.
Fixed font name.
Replaced opentype.js directory path with CDN link.

## Motivation and Context
The example page reading-wrting.html did not work anymore.

## How Has This Been Tested?
Created a localhost server and tested in chrome.
The characters are display correct now.
Download a font work again.

## Screenshots (if appropriate):
<img width="1837" alt="Screenshot 2023-04-16 at 10 39 29" src="https://user-images.githubusercontent.com/21055547/232287106-9dc7b912-96f8-457b-aef3-4023fd711655.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
