### PR TITLE
added support for friendly stylistic set names.

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -600,7 +600,9 @@ Parser.prototype.parseFeatureList = function() {
     return this.parsePointer(Parser.recordList({
         tag: Parser.tag,
         feature: Parser.pointer({
-            featureParams: Parser.offset16,
+            featureParams: Parser.pointer({
+                version: Parser.uShort, 
+                nameID: Parser.uShort}),
             lookupListIndexes: Parser.uShortList
         })
     })) || [];

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,6 +1,9 @@
 import assert from 'assert';
 import { unhex } from './testutil.js';
 import { Parser } from '../src/parse.js';
+import { Font, Path, Glyph, parse, load} from '../src/opentype.js';
+import { readFileSync } from 'fs';
+const loadSync = (url, opt) => parse(readFileSync(url), opt);
 
 describe('parse.js', function() {
     describe('parseUShortList', function() {
@@ -208,12 +211,32 @@ describe('parse.js', function() {
                 '0000 0001 0000   0000 0002 0000 0001   0000 0003 0000 0001 0002';
             const p = new Parser(unhex(data), 0);
             assert.deepEqual(p.parseFeatureList(), [
-                { tag: 'liga', feature: { featureParams: 0, lookupListIndexes: [0] } },
-                { tag: 'liga', feature: { featureParams: 0, lookupListIndexes: [0, 1] } },
-                { tag: 'liga', feature: { featureParams: 0, lookupListIndexes: [0, 1, 2] } }
+                { tag: 'liga', feature: { featureParams: null, lookupListIndexes: [0] } },
+                { tag: 'liga', feature: { featureParams: null, lookupListIndexes: [0, 1] } },
+                { tag: 'liga', feature: { featureParams: null, lookupListIndexes: [0, 1, 2] } }
             ]);
             assert.equal(p.relativeOffset, 2);
         });
+    });
+
+
+    describe('parsefeatureParams', function() {
+        const font = loadSync('./test/fonts/SourceSansPro-Regular.otf');
+        const ss01 = font.tables.gsub.features[73]
+        const aalt = font.tables.gsub.features[0]
+        assert.equal(ss01.tag, 'ss01'); // this one should have featureParams
+        assert.equal(aalt.tag, 'aalt'); // this one should not have featureParams
+
+        it('featureParams nameID of stylistic set ss01 should be 257', function() {
+            assert.equal(ss01.feature.featureParams.nameID, 257);
+        });
+        it('featureParams version of stylistic set ss01 should be 0', function() {
+            assert.equal(ss01.feature.featureParams.version, 0);
+        });
+        it('featureParams of aalt should be null', function() {
+            assert.equal(aalt.feature.featureParams, null);
+        });
+
     });
 
     describe('parseLookupList', function() {


### PR DESCRIPTION
## Description
Added featureParams to get friendly stylistic set name via given nameID if given.
For reference, see OT spec: https://docs.microsoft.com/en-us/typography/opentype/spec/features_pt#tag-ss01---ss20

## Motivation and Context
It's possible to give stylistc set features name name via ID. They are stored in the name table. This was not implemented into opentype.js, yet.

## How Has This Been Tested?
I added unittests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
