### PR TITLE
fix(glyph): Resolve the problem of invalid unicodes input parameters

### DIFF
--- a/src/glyph.js
+++ b/src/glyph.js
@@ -74,7 +74,7 @@ Glyph.prototype.bindConstructorValues = function(options) {
     // These three values cannot be deferred for memory optimization:
     this.name = options.name || null;
     this.unicode = options.unicode;
-    this.unicodes = options.unicodes || options.unicode !== undefined ? [options.unicode] : [];
+    this.unicodes = options.unicodes || (options.unicode !== undefined ? [options.unicode] : []);
 
     // But by binding these values only when necessary, we reduce can
     // the memory requirements by almost 3% for larger fonts.

--- a/test/glyph.js
+++ b/test/glyph.js
@@ -75,6 +75,7 @@ describe('glyph.js', function() {
         let glyph = new Glyph({
             name: 'Test Glyph',
             unicode: 65,
+            unicodes: [65, 66],
             path: new Path(),
             advanceWidth: 400,
             leftSideBearing: -100
@@ -85,7 +86,7 @@ describe('glyph.js', function() {
             assert.equal(glyph.unicode, 65);
             assert.equal(glyph.advanceWidth, 400);
             assert.equal(glyph.leftSideBearing, -100);
-            assert.deepEqual(glyph.unicodes, [65]);
+            assert.deepEqual(glyph.unicodes, [65, 66]);
         });
     });
 


### PR DESCRIPTION
Resolve the problem of invalid unicodes input parameters

## Description
When attempting to instantiate a Glyph object with multiple values in the options.unicodes parameter, the input does not take effect and instead becomes [unicode].

## Motivation and Context
To enable the 'unicodes' parameter

## How Has This Been Tested?
```javascript
const glyphOptions = {
  "index": 3548,
  "xMin": 58,
  "xMax": 947,
  "yMax": 825,
  "unicode": 12101,
  "unicodes": [
      12101,
      26041
  ],
  "advanceWidth": 1000,
  "leftSideBearing": 58,
  "name": "方",
}
const glyph = new opentype.Glyph(glyphOptions)
// It will be [ 12101, 26041 ]
console.log('glyph :>> ', glyph.unicodes);
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
