### PR TITLE
fix hasChar() for CMAP fonts and add tests (fix #330)

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -124,7 +124,7 @@ function Font(options) {
  * @return {Boolean}
  */
 Font.prototype.hasChar = function(c) {
-    return this.encoding.charToGlyphIndex(c) !== null;
+    return this.encoding.charToGlyphIndex(c) > 0;
 };
 
 /**

--- a/test/font.js
+++ b/test/font.js
@@ -92,4 +92,17 @@ describe('font.js', function() {
         });
 
     });
+
+    describe('hasChar', function() {
+        it('returns correct results for non-CMAP fonts', function() {
+            assert.equal(font.hasChar('i'), true);
+            assert.equal(font.hasChar('x'), false);
+        });
+
+        it('returns correct results for CMAP fonts', function() {
+            const cmapFont = loadSync('./test/fonts/TestCMAP14.otf');
+            assert.equal(cmapFont.hasChar('a'), false);
+            assert.equal(cmapFont.hasChar('≩'), true);
+        });
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For fonts using CMAP, `hasChar()` would always return `true`, even if the char was not contained. This wasn't caught because there was no corresponding test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #330

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a new test loading the existing CMAP test font and checking the `hasChar()` return values for existing and non-existing chars.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [X] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [X] I have read the **CONTRIBUTING** document.
