### PR TITLE
fix setting preferred subfamily

### DIFF
--- a/src/tables/sfnt.js
+++ b/src/tables/sfnt.js
@@ -316,15 +316,15 @@ function fontToSfntTable(font) {
     }
 
     if (!names.unicode.preferredSubfamily) {
-        names.unicode.preferredSubfamily = fontNamesUnicode.fontSubFamily || fontNamesMacintosh.fontSubFamily || fontNamesWindows.fontSubFamily;
+        names.unicode.preferredSubfamily = fontNamesUnicode.fontSubfamily || fontNamesMacintosh.fontSubfamily || fontNamesWindows.fontSubfamily;
     }
 
     if (!names.macintosh.preferredSubfamily) {
-        names.macintosh.preferredSubfamily = fontNamesMacintosh.fontSubFamily || fontNamesUnicode.fontSubFamily || fontNamesWindows.fontSubFamily;
+        names.macintosh.preferredSubfamily = fontNamesMacintosh.fontSubfamily || fontNamesUnicode.fontSubfamily || fontNamesWindows.fontSubfamily;
     }
 
     if (!names.windows.preferredSubfamily) {
-        names.windows.preferredSubfamily = fontNamesWindows.fontSubFamily || fontNamesUnicode.fontSubFamily || fontNamesMacintosh.fontSubFamily;
+        names.windows.preferredSubfamily = fontNamesWindows.fontSubfamily || fontNamesUnicode.fontSubfamily || fontNamesMacintosh.fontSubfamily;
     }
 
     // we have to handle fvar before name, because it may modify name IDs

--- a/test/font.js
+++ b/test/font.js
@@ -164,4 +164,12 @@ describe('font.js', function() {
             assert.equal(cmapFont.hasChar('≩'), true);
         });
     });
+
+    describe('toTables', function() {
+        it('returns an sfnt font table', function() {
+            const tables = font.toTables();
+            assert.ok(tables);
+            assert.equal(tables.tableName, 'sfnt');
+        });
+    });
 });

--- a/test/tables/sfnt.js
+++ b/test/tables/sfnt.js
@@ -29,15 +29,15 @@ describe('tables/sfnt.js', ()=>{
             font = new Font({...defaultFont});
         });
 
-        it('creates an sfnt table object', ()=>{
+        it('should create an sfnt table object', ()=>{
             const sfnt_table = sfnt.fontToTable(font);
             assert.ok(sfnt_table);
             assert.equal(sfnt_table.tableName, 'sfnt');
-        })
+        });
 
-        it('gives default values when no name values are set', ()=>{
+        it('should set default values when no name values are set', ()=>{
             const sfnt_table = sfnt.fontToTable(font);
-            const name_table = sfnt_table.tables.find((table)=>table.tableName == "name");
+            const name_table = sfnt_table.tables.find((table)=>table.tableName == 'name');
 
             assert.ok(name_table);
             
@@ -81,6 +81,72 @@ describe('tables/sfnt.js', ()=>{
                     preferredSubfamily: { en: defaultFont.styleName } // 'Medium'
                 }
             });
+        });
+
+        it('should set values in the names table with the values of the font object\'s names property', ()=>{
+            const fontFamily = 'Original Name';
+            const fontSubfamily = 'Bold Italic';
+            const fullName = 'Original Name Bold Italic';
+            const version = 'Version 24';
+            const preferredFamily = 'Custom Name';
+            const preferredSubfamily = '700 Italic';
+
+            font.names = {
+                macintosh: {
+                    fontFamily: { en: fontFamily },
+                    fontSubfamily: { en: fontSubfamily},
+                    fullName: { en: fullName },
+                    version: { en: version },
+                    preferredFamily: { en: preferredFamily },
+                    preferredSubfamily: { en: preferredSubfamily}
+                },
+                windows: {
+                    fontFamily: { en: fontFamily },
+                    fontSubfamily: { en: fontSubfamily},
+                    fullName: { en: fullName },
+                    version: { en: version },
+                    preferredFamily: { en: preferredFamily },
+                    preferredSubfamily: { en: preferredSubfamily}
+                }
+            };
+
+            const sfnt_table = sfnt.fontToTable(font);
+            const name_table = sfnt_table.tables.find((table)=>table.tableName == 'name');
+            const parsedNameTable = encodeAndParseTable(name_table, name.parse);
+
+            assert.deepEqual(parsedNameTable, {
+                macintosh: {
+                    fontFamily: { en: fontFamily },
+                    fontSubfamily: { en: fontSubfamily},
+                    fullName: { en: fullName },
+                    version: { en: version },
+                    preferredFamily: { en: preferredFamily },
+                    preferredSubfamily: { en: preferredSubfamily}
+                },
+                windows: {
+                    fontFamily: { en: fontFamily },
+                    fontSubfamily: { en: fontSubfamily},
+                    fullName: { en: fullName },
+                    version: { en: version },
+                    preferredFamily: { en: preferredFamily },
+                    preferredSubfamily: { en: preferredSubfamily}
+                }
+            });
+        });
+
+        it('should set preferredSubfamily as value of fontSubfamily, if not explicitly set', ()=>{
+            const preferredSubfamily = 'Custom Subfamily';
+            font.names = { macintosh: {
+                fontFamily: {en: defaultFont.familyName },
+                fontSubfamily: { en: preferredSubfamily }
+            }};
+
+            const sfnt_table = sfnt.fontToTable(font);
+            const name_table = sfnt_table.tables.find((table)=>table.tableName == 'name');
+            const parsedNameTable = encodeAndParseTable(name_table, name.parse);
+
+            assert.deepEqual(parsedNameTable.macintosh.preferredSubfamily, { en: preferredSubfamily });
+            assert.deepEqual(parsedNameTable.windows.preferredSubfamily, { en: preferredSubfamily });
         });
     });
 });

--- a/test/tables/sfnt.js
+++ b/test/tables/sfnt.js
@@ -1,0 +1,87 @@
+import assert from 'assert';
+import Font from '../../src/font.js';
+import sfnt from '../../src/tables/sfnt.js';
+import name from '../../src/tables/name.js';
+import { encode } from '../../src/types.js';
+
+function encodeAndParseTable(table, parser) {
+    const bytes = encode.TABLE(table);
+    const data = new DataView(new ArrayBuffer(bytes.length), 0);
+    for (let k = 0; k < bytes.length; k++) {
+        data.setUint8(k, bytes[k]);
+    }
+
+    return parser(data, 0);
+}
+
+describe('tables/sfnt.js', ()=>{
+    let font;
+    const defaultFont = {
+        familyName: 'MyFont',
+        styleName: 'Medium',
+        unitsPerEm: 1000,
+        ascender: 800,
+        descender: 0,
+    };
+
+    describe('fontToSfntTable', () => {
+        beforeEach(function() {
+            font = new Font({...defaultFont});
+        });
+
+        it('creates an sfnt table object', ()=>{
+            const sfnt_table = sfnt.fontToTable(font);
+            assert.ok(sfnt_table);
+            assert.equal(sfnt_table.tableName, 'sfnt');
+        })
+
+        it('gives default values when no name values are set', ()=>{
+            const sfnt_table = sfnt.fontToTable(font);
+            const name_table = sfnt_table.tables.find((table)=>table.tableName == "name");
+
+            assert.ok(name_table);
+            
+            const parsedNameTable = encodeAndParseTable(name_table, name.parse);
+
+            assert.deepEqual(parsedNameTable, {
+                macintosh: {
+                    copyright: { en: ' ' },
+                    fontFamily: { en: defaultFont.familyName }, // 'MyFont'
+                    fontSubfamily: { en: defaultFont.styleName }, // 'Medium'
+                    fullName: { en: `${defaultFont.familyName} ${defaultFont.styleName}` }, // 'MyFont Medium'
+                    version: { en: 'Version 0.1' },
+                    postScriptName: { en: `${defaultFont.familyName}${defaultFont.styleName}` }, // 'MyFontMedium'
+                    trademark: { en: ' ' },
+                    manufacturer: { en: ' ' },
+                    designer: { en: ' ' },
+                    description: { en: ' ' },
+                    manufacturerURL: { en: ' ' },
+                    designerURL: { en: ' ' },
+                    license: { en: ' ' },
+                    licenseURL: { en: ' ' },
+                    preferredFamily: { en: defaultFont.familyName }, // 'MyFont'
+                    preferredSubfamily: { en: defaultFont.styleName } // 'Medium'
+                },
+                windows: {
+                    copyright: { en: ' ' },
+                    fontFamily: { en: defaultFont.familyName }, // 'MyFont'
+                    fontSubfamily: { en: defaultFont.styleName }, // 'Medium'
+                    fullName: { en: `${defaultFont.familyName} ${defaultFont.styleName}` }, // 'MyFont Medium'
+                    version: { en: 'Version 0.1' },
+                    postScriptName: { en: `${defaultFont.familyName}${defaultFont.styleName}` }, // 'MyFontMedium'
+                    trademark: { en: ' ' },
+                    manufacturer: { en: ' ' },
+                    designer: { en: ' ' },
+                    description: { en: ' ' },
+                    manufacturerURL: { en: ' ' },
+                    designerURL: { en: ' ' },
+                    license: { en: ' ' },
+                    licenseURL: { en: ' ' },
+                    preferredFamily: { en: defaultFont.familyName }, // 'MyFont'
+                    preferredSubfamily: { en: defaultFont.styleName } // 'Medium'
+                }
+            });
+        });
+    });
+});
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed how a font's `preferredSubfamily` is set.
Currently in the `tables/sfnt.js` file inside `fontToSfntTable`, when setting a font's `preferredSubfamily` it's looking for `preferredSubFamily`, so if it's not already set it will always be `undefined`. Changed the `F` to an `f`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes `undefined` preferredSubfamily if it's not explicitly set

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing a feature from this [repo/site](https://github.com/eigilnikolajsen/commit-mono). which parses font files which does not have `macintosh.preferredSubfamily` set, but has `windows.preferredSubfamily` set. Specifically fonts from [here](https://github.com/eigilnikolajsen/commit-mono/tree/main/src/fonts/fontlab).  Launched the site locally using a simple http server and ran the customization feature from the site, while testing how the font object's `name` props change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
