### PR TITLE
performance: implement caching for roundDecimal() and prevent unnecessary recalculations

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -16,8 +16,25 @@ function Path() {
     this.strokeWidth = 1;
 }
 
+const decimalRoundingCache = {};
+
 function roundDecimal(float, places) {
-    return +(Math.round(float + 'e+' + places) + 'e-' + places);
+    const integerPart = Math.floor(float);
+    const decimalPart = float - integerPart;
+
+    if (!decimalRoundingCache[places]) {
+        decimalRoundingCache[places] = {};
+    }
+
+    if (decimalRoundingCache[places][decimalPart] !== undefined) {
+        const roundedDecimalPart = decimalRoundingCache[places][decimalPart];
+        return integerPart + roundedDecimalPart;
+    }
+    
+    const roundedDecimalPart = +(Math.round(decimalPart + 'e+' + places) + 'e-' + places);
+    decimalRoundingCache[places][decimalPart] = roundedDecimalPart;
+
+    return integerPart + roundedDecimalPart;
 }
 
 function optimizeCommands(commands) {
@@ -525,10 +542,11 @@ Path.prototype.toPathData = function(options) {
     options = createSVGOutputOptions(options);
 
     function floatToString(v) {
-        if (Math.round(v) === roundDecimal(v, options.decimalPlaces)) {
-            return '' + roundDecimal(v, options.decimalPlaces);
+        const rounded = roundDecimal(v, options.decimalPlaces);
+        if (Math.round(v) === rounded) {
+            return '' + rounded;
         } else {
-            return roundDecimal(v, options.decimalPlaces).toFixed(options.decimalPlaces);
+            return rounded.toFixed(options.decimalPlaces);
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implement caching for decimal rounding by storing the results for the decimal part of floats only and adding them to the significant part. Also avoid unnecessary recalculations by storing the value for reuse.

fixes #641 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using our performance test tool, we could see a huge drop (~1s vs ~6s) in performance from 1.3.4 to the current master. The culprit seems to have been the function `roundDecimal()` in `path.js` alone. That calculation seems to be very performance-hungry, however, it's the only way that I found so far to get reliable rounding of floats without losing precision.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the performance test tool in `docs/benchmark.html` comparing to version 1.3.4 before and after the optimization. Also ran `npm run test` as well as the unicode test tool to make sure it doesn't break passing tests.

## Screenshots (if appropriate):
before
![image](https://github.com/opentypejs/opentype.js/assets/13076806/e0676a96-8fae-4183-a184-554b56ae406f)

after
![image](https://github.com/opentypejs/opentype.js/assets/13076806/506d7265-c1a3-4de0-8a2f-4b2ae22930e6)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] <s>I have added tests to cover my changes.</s> (not applicable)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
