### PR TITLE
implement graceful loading via logging severity levels

### DIFF
--- a/docs/font-inspector.html
+++ b/docs/font-inspector.html
@@ -144,11 +144,23 @@ function showErrorMessage(message) {
     var el = document.getElementById('message');
     if (!message || message.trim().length === 0) {
         el.style.display = 'none';
+        el.innerHTML = '';
     } else {
         el.style.display = 'block';
+        el.innerHTML = `<p class="message-type-1">${message}</p>`;
     }
-    el.innerHTML = message;
 }
+
+function appendErrorMessage(message, type) {
+    var el = document.getElementById('message');
+    el.style.display = 'block';
+    el.innerHTML += `<p class="message-type-${type}">${message}</p>`;
+}
+
+document.addEventListener('opentypejs:message', function(event) {
+    const message = event.detail.message;
+    appendErrorMessage(message.toString(), message.type);
+});
 
 function sortKeys(dict) {
     var keys = [];
@@ -257,10 +269,11 @@ async function display(file, name) {
     }
     try {
         const data = await file.arrayBuffer();
-        onFontLoaded(opentype.parse(isWoff2 ? Module.decompress(data) : data));
         showErrorMessage('');
+        onFontLoaded(opentype.parse(isWoff2 ? Module.decompress(data) : data));
     } catch (err) {
         showErrorMessage(err.toString());
+        throw err;
     }
 }
 form.file.onchange = function(e) {

--- a/docs/glyph-inspector.html
+++ b/docs/glyph-inspector.html
@@ -92,11 +92,23 @@ function showErrorMessage(message) {
     var el = document.getElementById('message');
     if (!message || message.trim().length === 0) {
         el.style.display = 'none';
+        el.innerHTML = '';
     } else {
         el.style.display = 'block';
+        el.innerHTML = `<p class="message-type-1">${message}</p>`;
     }
-    el.innerHTML = message;
 }
+
+function appendErrorMessage(message, type) {
+    var el = document.getElementById('message');
+    el.style.display = 'block';
+    el.innerHTML += `<p class="message-type-${type}">${message}</p>`;
+}
+
+document.addEventListener('opentypejs:message', function(event) {
+    const message = event.detail.message;
+    appendErrorMessage(message.toString(), message.type);
+});
 
 function pathCommandToString(cmd) {
     var str = '<strong>' + cmd.type + '</strong> ' +
@@ -273,13 +285,19 @@ function renderGlyphItem(canvas, glyphIndex) {
     var cellMarkSize = 4;
     var ctx = canvas.getContext('2d');
     ctx.clearRect(0, 0, cellWidth, cellHeight);
-    if (glyphIndex >= window.font.numGlyphs) return;
+    const nGlyphs = window.font.numGlyphs || window.font.nGlyphs;
+    if (glyphIndex >= nGlyphs) return;
 
     ctx.fillStyle = '#606060';
     ctx.font = '9px sans-serif';
     ctx.fillText(glyphIndex, 1, cellHeight-1);
-    var glyph = window.font.glyphs.get(glyphIndex),
-        glyphWidth = glyph.advanceWidth * fontScale,
+    const glyph = window.font.glyphs.get(glyphIndex);
+    if (!glyph.advanceWidth) {
+        // force calculation of path data
+        glyph.getPath();
+    }
+    const advanceWidth = glyph.advanceWidth;
+    let glyphWidth = glyph.advanceWidth * fontScale,
         xmin = (cellWidth - glyphWidth)/2,
         xmax = (cellWidth + glyphWidth)/2,
         x0 = xmin;
@@ -314,7 +332,7 @@ function initGlyphDisplay(font) {
         h = glyphBgCanvas.height / pixelRatio,
         glyphW = w - glyphMargin*2,
         glyphH = h - glyphMargin*2,
-        head = font.tables.head,
+        head = getFontDimensions(font),
         maxHeight = head.yMax - head.yMin,
         ctx = glyphBgCanvas.getContext('2d');
 
@@ -331,12 +349,23 @@ function initGlyphDisplay(font) {
     ctx.clearRect(0, 0, w, h);
     ctx.fillStyle = '#a0a0a0';
     hline('Baseline', 0);
-    hline('yMax', font.tables.head.yMax);
-    hline('yMin', font.tables.head.yMin);
-    hline('Ascender', font.tables.hhea.ascender);
-    hline('Descender', font.tables.hhea.descender);
-    hline('Typo Ascender', font.tables.os2.sTypoAscender);
-    hline('Typo Descender', font.tables.os2.sTypoDescender);
+    hline('yMax', head.yMax);
+    hline('yMin', head.yMin);
+    hline('Ascender', font.tables.hhea ? font.tables.hhea.ascender : font.ascender || head.yMax);
+    hline('Descender', font.tables.hhea ? font.tables.hhea.descender : font.descender || head.yMin);
+    if (font.tables.os2) {
+        hline('Typo Ascender', font.tables.os2.sTypoAscender);
+        hline('Typo Descender', font.tables.os2.sTypoDescender);
+    }
+}
+
+function getFontDimensions(font) {
+    return font.isCFFFont ? {
+        xMin: font.tables.cff.topDict.fontBBox[0],
+        xMax: font.tables.cff.topDict.fontBBox[3] || 1000,
+        yMin: font.tables.cff.topDict.fontBBox[1] || -200,
+        yMax: font.tables.cff.topDict.fontBBox[2] || 1000
+    } :font.tables.head;
 }
 
 function onFontLoaded(font) {
@@ -344,7 +373,7 @@ function onFontLoaded(font) {
 
     var w = cellWidth - cellMarginLeftRight * 2,
         h = cellHeight - cellMarginTop - cellMarginBottom,
-        head = font.tables.head,
+        head = getFontDimensions(font),
         maxHeight = head.yMax - head.yMin;
     fontScale = Math.min(w/(head.xMax - head.xMin), h/maxHeight);
     fontSize = fontScale * font.unitsPerEm;
@@ -353,10 +382,11 @@ function onFontLoaded(font) {
     var pagination = document.getElementById("pagination");
     pagination.innerHTML = '';
     var fragment = document.createDocumentFragment();
-    var numPages = Math.ceil(font.numGlyphs / cellCount);
+    const nGlyphs = font.numGlyphs || font.nGlyphs;
+    var numPages = Math.ceil(nGlyphs / cellCount);
     for(var i = 0; i < numPages; i++) {
         var link = document.createElement('span');
-        var lastIndex = Math.min(font.numGlyphs-1, (i+1)*cellCount-1);
+        var lastIndex = Math.min(nGlyphs-1, (i+1)*cellCount-1);
         link.textContent = i*cellCount + '-' + lastIndex;
         link.id = 'p' + i;
         link.addEventListener('click', pageSelect, false);
@@ -378,7 +408,8 @@ function cellSelect(event) {
     var firstGlyphIndex = pageSelected*cellCount,
         cellIndex = +event.target.id.substr(1),
         glyphIndex = firstGlyphIndex + cellIndex;
-    if (glyphIndex < window.font.numGlyphs) {
+    const nGlyphs = window.font.numGlyphs || window.font.nGlyphs;
+    if (glyphIndex < nGlyphs) {
         displayGlyph(glyphIndex);
         displayGlyphData(glyphIndex);
     }
@@ -410,10 +441,11 @@ async function display(file, name) {
     }
     try {
         const data = await file.arrayBuffer();
-        onFontLoaded(opentype.parse(isWoff2 ? Module.decompress(data) : data));
         showErrorMessage('');
+        onFontLoaded(opentype.parse(isWoff2 ? Module.decompress(data) : data));
     } catch (err) {
         showErrorMessage(err.toString());
+        throw err;
     }
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -169,11 +169,23 @@ function showErrorMessage(message) {
     var el = document.getElementById('message');
     if (!message || message.trim().length === 0) {
         el.style.display = 'none';
+        el.innerHTML = '';
     } else {
         el.style.display = 'block';
+        el.innerHTML = `<p class="message-type-1">${message}</p>`;
     }
-    el.innerHTML = message;
 }
+
+function appendErrorMessage(message, type) {
+    var el = document.getElementById('message');
+    el.style.display = 'block';
+    el.innerHTML += `<p class="message-type-${type}">${message}</p>`;
+}
+
+document.addEventListener('opentypejs:message', function(event) {
+    const message = event.detail.message;
+    appendErrorMessage(message.toString(), message.type);
+});
 
 function onFontLoaded(font) {
     window.font = font;
@@ -217,10 +229,11 @@ async function display(file, name) {
     }
     try {
         const data = await file.arrayBuffer();
-        onFontLoaded(opentype.parse(isWoff2 ? Module.decompress(data) : data));
         showErrorMessage('');
+        onFontLoaded(opentype.parse(isWoff2 ? Module.decompress(data) : data));
     } catch (err) {
         showErrorMessage(err.toString());
+        throw err;
     }
 }
 

--- a/docs/site.css
+++ b/docs/site.css
@@ -107,14 +107,27 @@ canvas.text {
 
 #message {
     position: relative;
-    top: -3px;
-    background: red;
     color: white;
-    padding: 1px 5px;
     font-weight: bold;
-    border-radius: 2px;
     display: none;
 	clear: both;
+    padding-top: 1px;
+}
+
+#message p {
+    margin: 2px 0;
+    padding: 2px 5px;
+    border-radius: 0.25rem;
+    border: solid 1px;
+    background: #fff3cd;
+    color: #856404;
+    border-color: #ffeeba;
+}
+
+#message p.message-type-1 {
+    background: #f8d7da;
+    color: #721c24;
+    border-color: #f5c6cb;
 }
 
 .message {

--- a/src/font_REMOTE_153.js
+++ b/src/font_REMOTE_153.js
@@ -9,15 +9,15 @@ import Substitution from './substitution.js';
 import { isBrowser, checkArgument } from './util.js';
 import HintingTrueType from './hintingtt.js';
 import Bidi from './bidi.js';
-import { logger, ErrorTypes, MessageLogger } from './logger.js';
+import validation from './validation.js';
 
 function createDefaultNamesInfo(options) {
     return {
         fontFamily: {en: options.familyName || ' '},
         fontSubfamily: {en: options.styleName || ' '},
-        fullName: {en: options.fullName || (options.familyName || '') + ' ' + (options.styleName || '')},
+        fullName: {en: options.fullName || options.familyName + ' ' + options.styleName},
         // postScriptName may not contain any whitespace
-        postScriptName: {en: options.postScriptName || ((options.familyName || '') + (options.styleName || '')).replace(/\s/g, '')},
+        postScriptName: {en: options.postScriptName || (options.familyName + options.styleName).replace(/\s/g, '')},
         designer: {en: options.designer || ' '},
         designerURL: {en: options.designerURL || ' '},
         manufacturer: {en: options.manufacturer || ' '},
@@ -503,17 +503,15 @@ Font.prototype.getEnglishName = function(name) {
 
 /**
  * Validate
- * @type {MessageLogger}
  */
-Font.prototype.validation = new MessageLogger();
-Font.prototype.ErrorTypes = ErrorTypes;
+Font.prototype.validation = new validation.MessageStack();
 Font.prototype.validate = function() {
     const validationMessages = [];
     const _this = this;
 
     function assert(predicate, message) {
         if (!predicate) {
-            validationMessages.push(_this.validation.add(message, _this.ErrorTypes.WARNING));
+            validationMessages.push(_this.validation.add(message, validation.errorTypes.WARNING));
         }
     }
 
@@ -532,6 +530,8 @@ Font.prototype.validate = function() {
 
     // Dimension information
     assert(this.unitsPerEm > 0, 'No unitsPerEm specified.');
+
+    this.validation.logMessages();
     
     return validationMessages;
 };
@@ -548,7 +548,7 @@ Font.prototype.toTables = function() {
  * @deprecated Font.toBuffer is deprecated. Use Font.toArrayBuffer instead.
  */
 Font.prototype.toBuffer = function() {
-    logger.add('Font.toBuffer is deprecated. Use Font.toArrayBuffer instead.', this.ErrorTypes.DEPRECATED);
+    this.validation.add('Font.toBuffer is deprecated. Use Font.toArrayBuffer instead.', validation.errorTypes.DEPRECATED);
     return this.toArrayBuffer();
 };
 /**
@@ -591,7 +591,7 @@ Font.prototype.download = function(fileName) {
             event.initEvent('click', true, false);
             link.dispatchEvent(event);
         } else {
-            logger.add('Font file could not be downloaded. Try using a different browser.');
+            validation.add('Font file could not be downloaded. Try using a different browser.');
         }
     } else {
         const fs = require('fs');
@@ -664,4 +664,3 @@ Font.prototype.usWeightClasses = {
 };
 
 export default Font;
-export { createDefaultNamesInfo };

--- a/src/glyphset.js
+++ b/src/glyphset.js
@@ -37,7 +37,6 @@ function GlyphSet(font, glyphs) {
             this.glyphs[i] = glyph;
         }
     }
-
     this.length = (glyphs && glyphs.length) || 0;
 }
 
@@ -64,13 +63,15 @@ if(typeof Symbol !== 'undefined' && Symbol.iterator) {
 GlyphSet.prototype.get = function(index) {
     // this.glyphs[index] is 'undefined' when low memory mode is on. glyph is pushed on request only.
     if (this.glyphs[index] === undefined) {
+        if (typeof this.font._push !== 'function') return;
+        
         this.font._push(index);
         if (typeof this.glyphs[index] === 'function') {
             this.glyphs[index] = this.glyphs[index]();
         }
 
         let glyph = this.glyphs[index];
-        let unicodeObj = this.font._IndexToUnicodeMap[index];
+        let unicodeObj = this.font._IndexToUnicodeMap && this.font._IndexToUnicodeMap[index];
 
         if (unicodeObj) {
             for (let j = 0; j < unicodeObj.unicodes.length; j++)

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,141 @@
+import { isBrowser } from './util.js';
+
+/**
+ * @typedef {number} ErrorTypes
+ */
+
+/**
+ * @enum {ErrorTypes}
+ */
+const ErrorTypes = {
+    ERROR: 1,
+    WARNING: 2,
+    DEPRECATED: 4,
+    ALL: 32767
+};
+Object.freeze && Object.freeze(ErrorTypes);
+
+/**
+ * @enum {ErrorStrings}
+ */
+const errorStrings = {
+    1: 'ERROR',
+    2: 'WARNING',
+    4: 'DEPRECATED'
+};
+
+const logMethods = {
+    1: 'error',
+    2: 'warn',
+    4: 'info'
+};
+
+/**
+ * @property {string} string - message string
+ * @property {keyof ErrorTypes} type - error type
+ */
+class Message {
+    constructor(string, type = ErrorTypes.ERROR) {
+        if (!errorStrings[type]) {
+            throw new Error( 'Invalid error type ' + type + ' for message: ' + string );
+        }
+
+        this.string = string;
+        this.type = type;
+    }
+
+    toString() {
+        return errorStrings[this.type] + ': ' + this.string;
+    }
+}
+
+class MessageLogger {
+
+    constructor() {
+        this.logLevel = ErrorTypes.ALL;
+        this.throwLevel = ErrorTypes.ERROR;
+        this.ErrorTypes = ErrorTypes;
+    }
+    
+    /**
+     * Logs a message and fires the opentypejs:message Event.
+     * @property {String|Message} string
+     * @property {keyof ErrorTypes} type
+     * 
+     * @returns {Message}
+     */
+    add(stringOrMessage, type = ErrorTypes.ERROR) {
+        let message;
+        if (stringOrMessage instanceof Message) {
+            message = stringOrMessage;
+            type = message.type;
+        } else {
+            message = new Message(stringOrMessage, type);
+        }
+
+        let doLog = !!(this.logLevel & type);
+
+        if (isBrowser()) {
+            document.dispatchEvent(
+                new CustomEvent('opentypejs:message', {
+                    detail: {
+                        message,
+                        logged: doLog,
+                        logger: this.logLevel
+                    }
+                })
+            );
+        }
+        
+        if (doLog) {
+            this.logMessage(message);
+        }
+    
+        return message;
+    }
+
+    /**
+     * adds an array of messages
+     */
+    adds(messageArray) {
+        for (let i = 0; i < messageArray.length; i++) {
+            this.add(messageArray[i]);
+        }
+    }
+    
+    /**
+     * Logs a message to the console or throws it,
+     * depending on the throwLevel setting.
+     * @param {Message} message 
+     */
+    logMessage(message) {
+        const type = message.type || ErrorTypes.ERROR;
+        const logMethod = console[logMethods[type] || 'log'] || console.log;
+        const logMessage = '[opentype.js] ' + message.toString();
+        if ( this.throwLevel & type ) {
+            throw new Error(logMessage);
+        }
+        logMethod(logMessage);
+    }
+    
+    getLogLevel() {
+        return this.logLevel;
+    }
+
+    setLogLevel(newLevel) {
+        this.logLevel = newLevel;
+    }
+
+    getThrowLevel() {
+        return this.throwLevel;
+    }
+
+    setThrowLevel(newLevel) {
+        this.throwLevel = newLevel;
+    }
+    
+}
+
+const globalLogger = new MessageLogger();
+
+export { ErrorTypes, Message, MessageLogger, globalLogger as logger };

--- a/src/parse.js
+++ b/src/parse.js
@@ -37,15 +37,29 @@ function getFixed(dataView, offset) {
     return decimal + fraction / 65535;
 }
 
+// Retrieve a string with a specific byte length from the DataView.
+function getString(dataView, offset, length) {
+    let string = '';
+    
+    if (!offset) {
+        offset = 0;
+    }
+
+    if (length === undefined) {
+        length = dataView.byteLength - offset;
+    }
+
+    for (let i = offset; i < offset + length; i += 1) {
+        string += String.fromCharCode(dataView.getInt8(i));
+    }
+
+    return string;
+}
+
 // Retrieve a 4-character tag from the DataView.
 // Tags are used to identify tables.
 function getTag(dataView, offset) {
-    let tag = '';
-    for (let i = offset; i < offset + 4; i += 1) {
-        tag += String.fromCharCode(dataView.getInt8(i));
-    }
-
-    return tag;
+    return getString(dataView, offset, 4);
 }
 
 // Retrieve an offset from the DataView.
@@ -721,6 +735,7 @@ export default {
     getUInt24,
     getULong,
     getFixed,
+    getString,
     getTag,
     getOffset,
     getBytes,

--- a/src/types.js
+++ b/src/types.js
@@ -2,6 +2,7 @@
 // All OpenType fonts use Motorola-style byte ordering (Big Endian)
 
 import check from './check.js';
+import { logger } from './logger.js';
 
 const LIMIT16 = 32768; // The limit at which a 16-bit number switches signs == 2^15
 const LIMIT32 = 2147483648; // The limit at which a 32-bit number switches signs == 2 ^ 31
@@ -70,9 +71,9 @@ sizeOf.CHAR = constant(1);
  * @returns {Array}
  */
 encode.CHARARRAY = function(v) {
-    if (typeof v === 'undefined') {
+    if (v == null) { // catches undefined and null
         v = '';
-        console.warn('Undefined CHARARRAY encountered and treated as an empty string. This is probably caused by a missing glyph name.');
+        logger.add('Undefined CHARARRAY encountered and treated as an empty string. This is probably caused by a missing glyph name.', logger.ErrorTypes.WARNING);
     }
     const b = [];
     for (let i = 0; i < v.length; i += 1) {
@@ -183,7 +184,7 @@ sizeOf.LONG = constant(4);
  */
 encode.FLOAT = function(v) {
     if (v > MAX_16_16 || v < MIN_16_16) {
-        throw new Error(`Value ${v} is outside the range of representable values in 16.16 format`);
+        logger.add(`Value ${v} is outside the range of representable values in 16.16 format`, logger.ErrorTypes.ERROR);
     }
     const fixedValue = Math.round(v * (1 << 16)) << 0; // Round to nearest multiple of 1/(1<<16)
     return encode.ULONG(fixedValue);
@@ -856,7 +857,7 @@ encode.OPERAND = function(v, type) {
                 d.push(enc1[j]);
             }
         } else {
-            throw new Error('Unknown operand type ' + type);
+            logger.add('Unknown operand type ' + type, logger.ErrorTypes.ERROR);
             // FIXME Add support for booleans
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
**_This is a work in progress, but I wanted to get feedback before adding tests, changing all the instances of `console.*` and `throw` and adding to the documentation._**

This implements a logger that allows to log messages with different severities (`ERROR`, `WARNING`, `DEPRECATED`). By default, everything gets logged to the console, and only messages of type `ERROR` get thrown. This can be set via `setLogLevel()` and `setThrowLevel()`, using binary flags, e.g. `opentype.ErrorTypes.ALL ^ opentype.ErrorTypes.DEPRECATED` to log everything but `DEPRECATED` messages.

When adding a message to the log, this will also trigger a custom `opentypejs:message` event, so you can catch all the different message types, e.g. for displaying them on our demo pages. Speaking of which, those have also been adapted to handle missing values more gracefully and log multiple messages instead of just the last error thrown.

During initial parsing, many formerly thrown error messages have been changed to messages of type `WARNING`. This allows incomplete and corrupted fonts to load. To test one of those, I also implemented parsing of standalone CFF fonts, because it was fairly simple. Those are basically standalone CFF tables, so we had everything ready for parsing and just needed to handle some font information that we get from other tables in OpenType CFF files. Might need to extend that a bit further in the future, but it's OK for getting basic glyph and meta data.

Last but not least, the same logging functionality as above is used for `Font.validate()`. It uses a separate logger instance so the log and throw levels can be set differently from the global logger, and in any case the collected messages will be returned as an array so they can be handled separately.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #643, fix #426, fix #370, fix #337 (all related to subset font data)
fix #607 (`Font.validate()`)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested all the subset files provided (unfortunately can't simply use those for testing due to unclear licensing).

**TODO**
* add some general tests regarding error logging/handling
* find or produce some usable test files if I can
* add tests for `Font.validate()`

## Screenshots (if appropriate):
![image](https://github.com/opentypejs/opentype.js/assets/13076806/1f7f52dd-432a-4339-954b-7c724b73a23e)
`font.validate()` finally being useful

![image](https://github.com/opentypejs/opentype.js/assets/13076806/22c81cec-40ce-483a-bb42-2b5eb2415231)
Showing multiple warning messages in the demo

![image](https://github.com/opentypejs/opentype.js/assets/13076806/2196d68c-3771-450a-a33b-2fd1e045fe6e) ![image](https://github.com/opentypejs/opentype.js/assets/13076806/bff6a2d0-5f70-4201-a21d-bc9ea14a7bf2)
parsing subset fonts

![image](https://github.com/opentypejs/opentype.js/assets/13076806/d2c1ac10-aac3-4226-ad9d-cbefd57c7392)
parsing standalone CFF (subset) fonts

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] [TODO] *I have added tests to cover my changes.*
- [X] My change requires a change to the documentation.
- [ ] [TODO] *I have updated the **README** accordingly.*
- [X] I have read the **CONTRIBUTING** document.
