### PR TITLE
fix cmap table selection (fix #649)

### DIFF
--- a/src/tables/cmap.js
+++ b/src/tables/cmap.js
@@ -182,6 +182,8 @@ function parseCmapTable(data, start) {
             (platformId === 0 && platform0Encodings.includes(encodingId)) ||
             (platformId === 1 && encodingId === 0) // MacOS <= 9
         ) {
+            // only use the first supported table
+            if (offset > 0) continue;
             offset = parse.getULong(data, start + 4 + (i * 8) + 4);
             // allow for early break
             if (format14Parser) {
@@ -193,6 +195,9 @@ function parseCmapTable(data, start) {
             if (format14Parser.parseUShort() !== 14) {
                 format14offset = -1;
                 format14Parser = null;
+            } else if (offset > 0) {
+                // we already got the regular table, early break
+                break;
             }
         }
     }

--- a/test/opentypeSpec.js
+++ b/test/opentypeSpec.js
@@ -69,6 +69,7 @@ describe('opentype.js', function() {
         assert.equal(aGlyph.name, 'gid2');
         assert.equal(aGlyph.unicode, 1);
         assert.equal(aGlyph.path.commands.length, 24);
+        assert.deepEqual(font.stringToGlyphIndexes('🌺'), [59]);
     });
 
     it('can load a WOFF/CFF font', function() {
@@ -158,6 +159,7 @@ describe('opentype.js on low memory mode', function() {
         assert.equal(aGlyph.name, 'gid2');
         assert.equal(aGlyph.unicode, 1);
         assert.equal(aGlyph.path.commands.length, 24);
+        assert.deepEqual(font.stringToGlyphIndexes('🌺'), [59]);
     });
 
     it('can load a WOFF/CFF font', function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I introduced a bug with my PR #338, this is the fix for it. We always want to take the first CMAP table that we support, but keep on looking for an optional format 14 table that will be applied separately (this is the only exception, all other CMAP tables are exclusive). But I forgot to check if we already found a CMAP table when setting the offset for the supported table format, so it kept overriding the selected table until it found a format 14 table, thus always using the last instead of the first supported table.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #649, this bug broke the unicode test suite tests CFF-1 and CFF-2, and probably other fonts as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
loaded the FDArray test fonts and checked if the chars that broke in the test suite are displayed as expected

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [X] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [X] I have read the **CONTRIBUTING** document.
