### PR TITLE
Add a lineGap configuration option to the Font object

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -52,6 +52,7 @@ function createDefaultNamesInfo(options) {
  * @property {Number} unitsPerEm
  * @property {Number} ascender
  * @property {Number} descender
+ * @property {Number} lineGap
  * @property {Number} createdTimestamp
  * @property {Number} weightClass
  * @property {Number} italicAngle
@@ -91,6 +92,7 @@ function Font(options) {
         this.createdTimestamp = options.createdTimestamp;
         this.italicAngle = options.italicAngle || 0;
         this.weightClass = options.weightClass || 0;
+        this.lineGap = options.lineGap || 0;
 
         let selection = 0;
         if (options.fsSelection) {

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -320,6 +320,7 @@ function parseBuffer(buffer, opt={}) {
                 font.tables.hhea = hhea.parse(table.data, table.offset);
                 font.ascender = font.tables.hhea.ascender;
                 font.descender = font.tables.hhea.descender;
+                font.lineGap = font.tables.hhea.lineGap;
                 font.numberOfHMetrics = font.tables.hhea.numberOfHMetrics;
                 break;
             case 'hmtx':

--- a/src/tables/sfnt.js
+++ b/src/tables/sfnt.js
@@ -206,6 +206,7 @@ function fontToSfntTable(font) {
     };
     globals.ascender = font.ascender;
     globals.descender = font.descender;
+    globals.lineGap = font.lineGap;
 
     // macStyle bits must agree with the fsSelection bits
     let macStyle = 0;
@@ -214,7 +215,7 @@ function fontToSfntTable(font) {
     }
     if (font.italicAngle < 0) {
         macStyle |= font.macStyleValues.ITALIC;
-    } 
+    }
 
     const headTable = head.make({
         flags: 3, // 00000011 (baseline for font at y=0; left sidebearing point at x=0)
@@ -229,6 +230,7 @@ function fontToSfntTable(font) {
     });
 
     const hheaTable = hhea.make({
+        lineGap: globals.lineGap,
         ascender: globals.ascender,
         descender: globals.descender,
         advanceWidthMax: globals.advanceWidthMax,
@@ -254,7 +256,7 @@ function fontToSfntTable(font) {
         // ordering was chosen experimentally.
         sTypoAscender: globals.ascender,
         sTypoDescender: globals.descender,
-        sTypoLineGap: 0,
+        sTypoLineGap: globals.lineGap || 0,
         usWinAscent: globals.yMax,
         usWinDescent: Math.abs(globals.yMin),
         ulCodePageRange1: 1, // FIXME: hard-code Latin 1 support for now

--- a/test/font.js
+++ b/test/font.js
@@ -28,6 +28,7 @@ describe('font.js', function() {
             ascender: 800,
             descender: 0,
             fsSelection: 42,
+            lineGap: 500,
             tables: {os2: {achVendID: 'TEST'}},
             glyphs: glyphs
         });
@@ -36,6 +37,9 @@ describe('font.js', function() {
     describe('Font constructor', function() {
         it('accept 0 as descender value', function() {
             assert.equal(font.descender, 0);
+        });
+        it('accept 500 as lineGap value', function() {
+            assert.equal(font.lineGap, 500);
         });
         it('tables definition must be supported', function() {
             assert.equal(font.tables.os2.achVendID, 'TEST');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a 'lineGap' configuration option to the Font object.

## Description
<!--- Describe your changes in detail -->
Add a 'lineGap' configuration option to the Font object, so that the generated font file when calling toArrayBuffer includes the 'lineGap' property.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I need the 'lineGap' property to calculate the automatic height of text. Currently, the generated font file does not include this property, which causes inaccuracies in my text's automatic height calculation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```javascript
const font = new Font({
    familyName: 'MyFont',
    styleName: 'Medium',
    unitsPerEm: 1000,
    ascender: 800,
    descender: 0,
    fsSelection: 42,
    lineGap: 500,
    tables: {os2: {achVendID: 'TEST'}},
    glyphs: glyphs
});
// It will be 500
console.log('font.lineGap :>> ', font.lineGap)

const buffer = font.toArrayBuffer()
const f = opentype.parse(buffer)
// It will be 500
console.log('f.lineGap :>> ', f.lineGap)
// It will be 500
console.log('f.tables.hhea.lineGap :>> ', f.tables.hhea.lineGap)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
