### PR TITLE
Replaced concat with push for better performance per #682

### DIFF
--- a/src/tables/cmap.js
+++ b/src/tables/cmap.js
@@ -277,14 +277,14 @@ function makeCmapTable(glyphs) {
     ];
 
     if (!isPlan0Only)
-        cmapTable = cmapTable.concat([
+        cmapTable.push(...[
             // CMAP 12 header
             {name: 'cmap12PlatformID', type: 'USHORT', value: 3}, // We encode only for PlatformID = 3 (Windows) because it is supported everywhere
             {name: 'cmap12EncodingID', type: 'USHORT', value: 10},
             {name: 'cmap12Offset', type: 'ULONG', value: 0}
         ]);
 
-    cmapTable = cmapTable.concat([
+    cmapTable.push(...[
         // CMAP 4 Subtable
         {name: 'format', type: 'USHORT', value: 4},
         {name: 'cmap4Length', type: 'USHORT', value: 0},
@@ -303,11 +303,10 @@ function makeCmapTable(glyphs) {
         for (let j = 0; j < glyph.unicodes.length; j += 1) {
             addSegment(t, glyph.unicodes[j], i);
         }
-
-        t.segments = t.segments.sort(function (a, b) {
-            return a.start - b.start;
-        });
     }
+    t.segments.sort(function (a, b) {
+        return a.start - b.start;
+    });
 
     addTerminatorSegment(t);
 
@@ -334,12 +333,12 @@ function makeCmapTable(glyphs) {
 
         // CMAP 4
         if (segment.end <= 65535 && segment.start <= 65535) {
-            endCounts = endCounts.concat({name: 'end_' + i, type: 'USHORT', value: segment.end});
-            startCounts = startCounts.concat({name: 'start_' + i, type: 'USHORT', value: segment.start});
-            idDeltas = idDeltas.concat({name: 'idDelta_' + i, type: 'SHORT', value: segment.delta});
-            idRangeOffsets = idRangeOffsets.concat({name: 'idRangeOffset_' + i, type: 'USHORT', value: segment.offset});
+            endCounts.push({name: 'end_' + i, type: 'USHORT', value: segment.end});
+            startCounts.push({name: 'start_' + i, type: 'USHORT', value: segment.start});
+            idDeltas.push({name: 'idDelta_' + i, type: 'SHORT', value: segment.delta});
+            idRangeOffsets.push({name: 'idRangeOffset_' + i, type: 'USHORT', value: segment.offset});
             if (segment.glyphId !== undefined) {
-                glyphIds = glyphIds.concat({name: 'glyph_' + i, type: 'USHORT', value: segment.glyphId});
+                glyphIds.push({name: 'glyph_' + i, type: 'USHORT', value: segment.glyphId});
             }
         } else {
             // Skip Unicode > 65535 (16bit unsigned max) for CMAP 4, will be added in CMAP 12
@@ -349,9 +348,9 @@ function makeCmapTable(glyphs) {
         // CMAP 12
         // Skip Terminator Segment
         if (!isPlan0Only && segment.glyphIndex !== undefined) {
-            cmap12Groups = cmap12Groups.concat({name: 'cmap12Start_' + i, type: 'ULONG', value: segment.start});
-            cmap12Groups = cmap12Groups.concat({name: 'cmap12End_' + i, type: 'ULONG', value: segment.end});
-            cmap12Groups = cmap12Groups.concat({name: 'cmap12Glyph_' + i, type: 'ULONG', value: segment.glyphIndex});
+            cmap12Groups.push({name: 'cmap12Start_' + i, type: 'ULONG', value: segment.start});
+            cmap12Groups.push({name: 'cmap12End_' + i, type: 'ULONG', value: segment.end});
+            cmap12Groups.push({name: 'cmap12Glyph_' + i, type: 'ULONG', value: segment.glyphIndex});
         }
     }
 
@@ -361,12 +360,22 @@ function makeCmapTable(glyphs) {
     t.entrySelector = Math.log(t.searchRange / 2) / Math.log(2);
     t.rangeShift = t.segCountX2 - t.searchRange;
 
-    t.fields = t.fields.concat(endCounts);
+    for (let i = 0; i < endCounts.length; i++) {
+        t.fields.push(endCounts[i]);
+    }
     t.fields.push({name: 'reservedPad', type: 'USHORT', value: 0});
-    t.fields = t.fields.concat(startCounts);
-    t.fields = t.fields.concat(idDeltas);
-    t.fields = t.fields.concat(idRangeOffsets);
-    t.fields = t.fields.concat(glyphIds);
+    for (let i = 0; i < startCounts.length; i++) {
+        t.fields.push(startCounts[i]);
+    }
+    for (let i = 0; i < idDeltas.length; i++) {
+        t.fields.push(idDeltas[i]);
+    }
+    for (let i = 0; i < idRangeOffsets.length; i++) {
+        t.fields.push(idRangeOffsets[i]);
+    }
+    for (let i = 0; i < glyphIds.length; i++) {
+        t.fields.push(glyphIds[i]);
+    }
 
     t.cmap4Length = 14 + // Subtable header
         endCounts.length * 2 +
@@ -382,7 +391,7 @@ function makeCmapTable(glyphs) {
             cmap12Groups.length * 4;
 
         t.cmap12Offset = 12 + (2 * 2) + 4 + t.cmap4Length;
-        t.fields = t.fields.concat([
+        t.fields.push(...[
             {name: 'cmap12Format', type: 'USHORT', value: 12},
             {name: 'cmap12Reserved', type: 'USHORT', value: 0},
             {name: 'cmap12Length', type: 'ULONG', value: cmap12Length},
@@ -390,7 +399,10 @@ function makeCmapTable(glyphs) {
             {name: 'cmap12nGroups', type: 'ULONG', value: cmap12Groups.length / 3}
         ]);
 
-        t.fields = t.fields.concat(cmap12Groups);
+        for (let i = 0; i < cmap12Groups.length; i++) {
+            t.fields.push(cmap12Groups[i]);
+        }
+        
     }
 
     return t;


### PR DESCRIPTION
## Description
Replaces instances of `d = d.concat(...)` with `push` within `cmap` functions for improved performance per https://github.com/opentypejs/opentype.js/issues/682. Should not impact results.  Conceptually speaking, this is almost identical to #513.

Additionally, `t.segments.sort` was being run *every time* a new element was added within a loop; I edited to only run once after all elements are inserted. 

## Motivation and Context
See #682.  In short, the performance of `font.toArrayBuffer()` can be poor, including >30+ second runtimes for certain large fonts.  This PR fixes that.

On my system (Chrome, Windows 10), this PR reduces the runtime for writing NotoSansSC from 36 seconds to 8 seconds (78% reduction), and reduces the runtime for NotoSerifSC from 33 seconds to 8 seconds (76% reduction).  

## How Has This Been Tested?
The unit tests pass and I am using a version with these changes in my project. Additionally, the change is conceptually simple and narrow in scope.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
