### PR TITLE
add local eslint rule rule for banning concat and new performance test

### DIFF
--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,6 +1,30 @@
 'use strict';
 
 module.exports = {
+  'ban-concat': {
+    meta: {
+      type: 'suggestion',
+      schema: [],
+    },
+    create(context) {
+      return {
+        CallExpression(node) {
+          if (
+            (
+              node.callee.property &&
+              node.callee.property.name === 'concat' &&
+              node.callee?.object?.name !== 'Buffer'
+            ) || (
+              node.callee?.object?.property?.name === 'concat' &&
+              node.callee?.object?.object?.type === 'ArrayExpression'
+            )
+          ) {
+            context.report({node, message: 'Use obj.push(...data) instead of obj = obj.concat(data)'})
+          }
+        },
+      }
+    },
+  },
   'ban-foreach': {
     meta: {
       type: 'suggestion',

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
         "error",
         "always"
       ],
+      "local-rules/ban-concat": 2,
       "local-rules/ban-foreach": 2,
       "local-rules/import-extensions": 2
     }

--- a/src/bidi.js
+++ b/src/bidi.js
@@ -101,8 +101,7 @@ Bidi.prototype.registerFeatures = function (script, tags) {
     if (!Object.prototype.hasOwnProperty.call(this.featuresTags, script)) {
         this.featuresTags[script] = supportedTags;
     } else {
-        this.featuresTags[script] =
-        this.featuresTags[script].concat(supportedTags);
+        this.featuresTags[script].push(...supportedTags);
     }
 };
 

--- a/src/features/arab/arabicPresentationForms.js
+++ b/src/features/arab/arabicPresentationForms.js
@@ -12,7 +12,8 @@ import applySubstitution from '../applySubstitution.js';
  * @param {ContextParams} charContextParams context params of a char
  */
 function willConnectPrev(charContextParams) {
-    let backtrack = [].concat(charContextParams.backtrack);
+    let backtrack = [...charContextParams.backtrack];
+
     for (let i = backtrack.length - 1; i >= 0; i--) {
         const prevChar = backtrack[i];
         const isolated = isIsolatedArabicChar(prevChar);

--- a/src/features/featureQuery.js
+++ b/src/features/featureQuery.js
@@ -128,7 +128,7 @@ function chainingSubstitutionFormat3(contextParams, subtable) {
         subtable.lookaheadCoverage, lookaheadParams
     );
     // BACKTRACK LOOKUP //
-    let backtrackContext = [].concat(contextParams.backtrack);
+    let backtrackContext = [...contextParams.backtrack];
     backtrackContext.reverse();
     while (backtrackContext.length && isTashkeelArabicChar(backtrackContext[0].char)) {
         backtrackContext.shift();
@@ -375,7 +375,7 @@ FeatureQuery.prototype.lookupFeature = function (query) {
         `for script '${query.script}'.`
     );
     const lookups = this.getFeatureLookups(feature);
-    const substitutions = [].concat(contextParams.context);
+    const substitutions = [...contextParams.context];
     for (let l = 0; l < lookups.length; l++) {
         const lookupTable = lookups[l];
         const subtables = this.getLookupSubtables(lookupTable);

--- a/src/path.js
+++ b/src/path.js
@@ -74,8 +74,7 @@ function optimizeCommands(commands) {
             }
         }
     }
-    commands = [].concat.apply([], subpaths); // flatten again
-    return commands;
+    return [...subpaths.flat()]; // flatten again
 }
 
 /**

--- a/src/substitution.js
+++ b/src/substitution.js
@@ -161,7 +161,7 @@ Substitution.prototype.getLigatures = function(feature, script, language) {
                 for (let k = 0; k < ligSet.length; k++) {
                     const lig = ligSet[k];
                     ligatures.push({
-                        sub: [startGlyph].concat(lig.components),
+                        sub: [startGlyph, ...lig.components],
                         by: lig.ligGlyph
                     });
                 }
@@ -309,15 +309,19 @@ Substitution.prototype.getFeature = function(feature, script, language) {
     switch (feature) {
         case 'aalt':
         case 'salt':
-            return this.getSingle(feature, script, language)
-                .concat(this.getAlternates(feature, script, language));
+            return [
+                ...this.getSingle(feature, script, language),
+                ...this.getAlternates(feature, script, language)
+            ];
         case 'dlig':
         case 'liga':
         case 'rlig':
             return this.getLigatures(feature, script, language);
         case 'ccmp':
-            return this.getMultiple(feature, script, language)
-                .concat(this.getLigatures(feature, script, language));
+            return [
+                ...this.getMultiple(feature, script, language),
+                ...this.getLigatures(feature, script, language)
+            ];              
         case 'stch':
             return this.getMultiple(feature, script, language);
     }

--- a/src/tables/avar.js
+++ b/src/tables/avar.js
@@ -20,10 +20,10 @@ function makeAvarSegmentMap(n, axis) {
     let axisValueMaps = [];
     for (let i = 0; i < axis.axisValueMaps.length; i++) {
         const valueMap = makeAvarAxisValueMap(`${n}_${i}`, axis.axisValueMaps[i]);
-        axisValueMaps = axisValueMaps.concat(valueMap.fields);
+        axisValueMaps.push(...valueMap.fields);
     }
 
-    returnTable.fields = returnTable.fields.concat(axisValueMaps);
+    returnTable.fields.push(...axisValueMaps);
 
     return returnTable;
 }
@@ -40,7 +40,7 @@ function makeAvarTable(avar, fvar) {
 
     for (let i = 0; i < avar.axisSegmentMaps.length; i++) {
         const axisRecord = makeAvarSegmentMap(i, avar.axisSegmentMaps[i]);
-        result.fields = result.fields.concat(axisRecord.fields);
+        result.fields.push(...axisRecord.fields);
     }
 
     return result;

--- a/src/tables/cmap.js
+++ b/src/tables/cmap.js
@@ -277,14 +277,14 @@ function makeCmapTable(glyphs) {
     ];
 
     if (!isPlan0Only)
-        cmapTable = cmapTable.concat([
+        cmapTable.push(...[
             // CMAP 12 header
             {name: 'cmap12PlatformID', type: 'USHORT', value: 3}, // We encode only for PlatformID = 3 (Windows) because it is supported everywhere
             {name: 'cmap12EncodingID', type: 'USHORT', value: 10},
             {name: 'cmap12Offset', type: 'ULONG', value: 0}
         ]);
 
-    cmapTable = cmapTable.concat([
+    cmapTable.push(...[
         // CMAP 4 Subtable
         {name: 'format', type: 'USHORT', value: 4},
         {name: 'cmap4Length', type: 'USHORT', value: 0},
@@ -303,11 +303,10 @@ function makeCmapTable(glyphs) {
         for (let j = 0; j < glyph.unicodes.length; j += 1) {
             addSegment(t, glyph.unicodes[j], i);
         }
-
-        t.segments = t.segments.sort(function (a, b) {
-            return a.start - b.start;
-        });
     }
+    t.segments.sort(function (a, b) {
+        return a.start - b.start;
+    });
 
     addTerminatorSegment(t);
 
@@ -334,12 +333,12 @@ function makeCmapTable(glyphs) {
 
         // CMAP 4
         if (segment.end <= 65535 && segment.start <= 65535) {
-            endCounts = endCounts.concat({name: 'end_' + i, type: 'USHORT', value: segment.end});
-            startCounts = startCounts.concat({name: 'start_' + i, type: 'USHORT', value: segment.start});
-            idDeltas = idDeltas.concat({name: 'idDelta_' + i, type: 'SHORT', value: segment.delta});
-            idRangeOffsets = idRangeOffsets.concat({name: 'idRangeOffset_' + i, type: 'USHORT', value: segment.offset});
+            endCounts.push({name: 'end_' + i, type: 'USHORT', value: segment.end});
+            startCounts.push({name: 'start_' + i, type: 'USHORT', value: segment.start});
+            idDeltas.push({name: 'idDelta_' + i, type: 'SHORT', value: segment.delta});
+            idRangeOffsets.push({name: 'idRangeOffset_' + i, type: 'USHORT', value: segment.offset});
             if (segment.glyphId !== undefined) {
-                glyphIds = glyphIds.concat({name: 'glyph_' + i, type: 'USHORT', value: segment.glyphId});
+                glyphIds.push({name: 'glyph_' + i, type: 'USHORT', value: segment.glyphId});
             }
         } else {
             // Skip Unicode > 65535 (16bit unsigned max) for CMAP 4, will be added in CMAP 12
@@ -349,9 +348,9 @@ function makeCmapTable(glyphs) {
         // CMAP 12
         // Skip Terminator Segment
         if (!isPlan0Only && segment.glyphIndex !== undefined) {
-            cmap12Groups = cmap12Groups.concat({name: 'cmap12Start_' + i, type: 'ULONG', value: segment.start});
-            cmap12Groups = cmap12Groups.concat({name: 'cmap12End_' + i, type: 'ULONG', value: segment.end});
-            cmap12Groups = cmap12Groups.concat({name: 'cmap12Glyph_' + i, type: 'ULONG', value: segment.glyphIndex});
+            cmap12Groups.push({name: 'cmap12Start_' + i, type: 'ULONG', value: segment.start});
+            cmap12Groups.push({name: 'cmap12End_' + i, type: 'ULONG', value: segment.end});
+            cmap12Groups.push({name: 'cmap12Glyph_' + i, type: 'ULONG', value: segment.glyphIndex});
         }
     }
 
@@ -361,12 +360,22 @@ function makeCmapTable(glyphs) {
     t.entrySelector = Math.log(t.searchRange / 2) / Math.log(2);
     t.rangeShift = t.segCountX2 - t.searchRange;
 
-    t.fields = t.fields.concat(endCounts);
+    for (let i = 0; i < endCounts.length; i++) {
+        t.fields.push(endCounts[i]);
+    }
     t.fields.push({name: 'reservedPad', type: 'USHORT', value: 0});
-    t.fields = t.fields.concat(startCounts);
-    t.fields = t.fields.concat(idDeltas);
-    t.fields = t.fields.concat(idRangeOffsets);
-    t.fields = t.fields.concat(glyphIds);
+    for (let i = 0; i < startCounts.length; i++) {
+        t.fields.push(startCounts[i]);
+    }
+    for (let i = 0; i < idDeltas.length; i++) {
+        t.fields.push(idDeltas[i]);
+    }
+    for (let i = 0; i < idRangeOffsets.length; i++) {
+        t.fields.push(idRangeOffsets[i]);
+    }
+    for (let i = 0; i < glyphIds.length; i++) {
+        t.fields.push(glyphIds[i]);
+    }
 
     t.cmap4Length = 14 + // Subtable header
         endCounts.length * 2 +
@@ -382,7 +391,7 @@ function makeCmapTable(glyphs) {
             cmap12Groups.length * 4;
 
         t.cmap12Offset = 12 + (2 * 2) + 4 + t.cmap4Length;
-        t.fields = t.fields.concat([
+        t.fields.push(...[
             {name: 'cmap12Format', type: 'USHORT', value: 12},
             {name: 'cmap12Reserved', type: 'USHORT', value: 0},
             {name: 'cmap12Length', type: 'ULONG', value: cmap12Length},
@@ -390,7 +399,10 @@ function makeCmapTable(glyphs) {
             {name: 'cmap12nGroups', type: 'ULONG', value: cmap12Groups.length / 3}
         ]);
 
-        t.fields = t.fields.concat(cmap12Groups);
+        for (let i = 0; i < cmap12Groups.length; i++) {
+            t.fields.push(cmap12Groups[i]);
+        }
+        
     }
 
     return t;

--- a/src/tables/fvar.js
+++ b/src/tables/fvar.js
@@ -99,11 +99,11 @@ function makeFvarTable(fvar, names) {
     result.offsetToData = result.sizeOf();
 
     for (let i = 0; i < fvar.axes.length; i++) {
-        result.fields = result.fields.concat(makeFvarAxis(i, fvar.axes[i], names));
+        result.fields.push(...makeFvarAxis(i, fvar.axes[i], names));
     }
 
     for (let j = 0; j < fvar.instances.length; j++) {
-        result.fields = result.fields.concat(makeFvarInstance(j, fvar.instances[j], fvar.axes, names));
+        result.fields.push(...makeFvarInstance(j, fvar.instances[j], fvar.axes, names));
     }
 
     return result;

--- a/src/tables/glyf.js
+++ b/src/tables/glyf.js
@@ -290,7 +290,7 @@ function buildPath(glyphs, glyph) {
                     transform.dy = firstPt.y - secondPt.y;
                     transformedPoints = transformPoints(componentGlyph.points, transform);
                 }
-                glyph.points = glyph.points.concat(transformedPoints);
+                glyph.points.push(...transformedPoints);
             }
         }
     }

--- a/src/tables/sfnt.js
+++ b/src/tables/sfnt.js
@@ -104,8 +104,7 @@ function makeSfntTable(tables) {
         }
     });
 
-    sfnt.fields = sfnt.fields.concat(recordFields);
-    sfnt.fields = sfnt.fields.concat(tableFields);
+    sfnt.fields.push(...recordFields, ...tableFields);
     return sfnt;
 }
 

--- a/src/tables/stat.js
+++ b/src/tables/stat.js
@@ -180,10 +180,10 @@ axisValueMakers[4] = function axisValueMaker4(n, table) {
     ];
 
     for (let i = 0; i < table.axisValues.length; i++) {
-        returnFields = returnFields.concat([
+        returnFields.push(
             {name: `format${n}axisIndex${i}`, type: 'USHORT', value: table.axisValues[i].axisIndex},
             {name: `format${n}value${i}`, type: 'FLOAT', value: table.axisValues[i].value},
-        ]);
+        );
     }
 
     return returnFields;
@@ -222,7 +222,7 @@ function makeSTATTable(STAT) {
     for (let i = 0; i < STAT.axes.length; i++) {
         const axisRecord = makeSTATAxisRecord(i, STAT.axes[i]);
         result.offsetToAxisValueOffsets += axisRecord.sizeOf();
-        result.fields = result.fields.concat(axisRecord.fields);
+        result.fields.push(...axisRecord.fields);
     }
 
     const axisValueOffsets = [];
@@ -237,11 +237,10 @@ function makeSTATTable(STAT) {
             value: axisValueTableOffset
         });
         axisValueTableOffset += axisValueTable.sizeOf();
-        axisValueTables = axisValueTables.concat(axisValueTable.fields);
+        axisValueTables.push(...axisValueTable.fields);
     }
 
-    result.fields = result.fields.concat(axisValueOffsets);
-    result.fields = result.fields.concat(axisValueTables);
+    result.fields.push(...axisValueOffsets, ...axisValueTables);
 
     return result;
 }

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -154,7 +154,7 @@ Tokenizer.prototype.inboundIndex = function(index) {
 Tokenizer.prototype.composeRUD = function (RUDs) {
     const silent = true;
     const state = RUDs.map(RUD => (
-        this[RUD[0]].apply(this, RUD.slice(1).concat(silent))
+        this[RUD[0]].apply(this, [...RUD.slice(1), silent])
     ));
     const hasFAILObject = obj => (
         typeof obj === 'object' &&
@@ -181,7 +181,7 @@ Tokenizer.prototype.replaceRange = function (startIndex, offset, tokens, silent)
     const isTokenType = tokens.every(token => token instanceof Token);
     if (!isNaN(startIndex) && this.inboundIndex(startIndex) && isTokenType) {
         const replaced = this.tokens.splice.apply(
-            this.tokens, [startIndex, offset].concat(tokens)
+            this.tokens, [startIndex, offset, ...tokens]
         );
         if (!silent) this.dispatch('replaceToken', [startIndex, offset, tokens]);
         return [replaced, tokens];
@@ -246,8 +246,8 @@ Tokenizer.prototype.insertToken = function (tokens, index, silent) {
     );
     if (tokenType) {
         this.tokens.splice.apply(
-            this.tokens, [index, 0].concat(tokens)
-        );
+            this.tokens, [index, 0, ...tokens]
+        );        
         if (!silent) this.dispatch('insertToken', [tokens, index]);
         return tokens;
     } else {
@@ -420,10 +420,10 @@ Tokenizer.prototype.registerContextChecker = function(contextName, contextStartC
  */
 Tokenizer.prototype.getRangeTokens = function(range) {
     const endIndex = range.startIndex + range.endOffset;
-    return [].concat(
-        this.tokens
-            .slice(range.startIndex, endIndex)
-    );
+    return [
+        ...this.tokens.slice(range.startIndex, endIndex)
+    ];
+      
 };
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -753,10 +753,12 @@ encode.INDEX = function(l) {
         Array.prototype.push.apply(encodedOffsets, encodedOffset);
     }
 
-    return Array.prototype.concat(encode.Card16(l.length),
-        encode.OffSize(offSize),
-        encodedOffsets,
-        data);
+    return [
+        ...encode.Card16(l.length),
+        ...encode.OffSize(offSize),
+        ...encodedOffsets,
+        ...data
+    ];
 };
 
 /**

--- a/test/fonts/LICENSE
+++ b/test/fonts/LICENSE
@@ -26,6 +26,12 @@ Jomhuria-Regular.ttf
     SIL Open Font License, Version 1.1.
     https://www.fontsquirrel.com/license/jomhuria
 
+notosanssc-bold.ttf
+NotoSansThai-Medium-Testing-v1.ttf
+    Copyright 2012 Google Inc. All Rights Reserved.
+    SIL Open Font License v1.10
+    https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL
+
 Roboto-Black.ttf
     Font data copyright Google 2012
     Apache License Version 2.0, January 2004

--- a/test/performance.js
+++ b/test/performance.js
@@ -1,0 +1,17 @@
+import assert from 'assert';
+import { parse } from '../src/opentype.js';
+import { readFileSync } from 'fs';
+import { performance } from 'perf_hooks';
+const loadSync = (url, opt) => parse(readFileSync(url), opt);
+
+describe('performance tests', function() {
+    const notoSansSC = loadSync('./test/fonts/notosanssc-bold.ttf');
+    
+    it('should not take too long to use toArrayBuffer() on large fonts', function() {
+        const start = performance.now();
+        const time = performance.now() - start;
+        notoSansSC.toArrayBuffer();
+        assert(time < 16000, true);
+    }).timeout(16000);
+});
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a test for #683 as well as a new local eslint rule for banning `concat()`. In favour of `push(...)`.
It also refactors all instances of `concat()` throughout the code base, so we should wait for several other outstanding PRs before merging this, in order to avoid a mass of conflicts. This PR is also blocked by #683 because it depends on it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#513 and #683 show a clear performance improvement especially for larger/more complex fonts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Made sure the tests are all still passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] performance improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [X] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [X] I have read the **CONTRIBUTING** document.
