### PR TITLE
Output module file with .mjs extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Select one of the following sources in the next example:
 
 <!-- using module declaration (need full path) -->
 <script type=module>
-import { parse } from "https://unpkg.com/opentype.js/dist/opentype.module.js";
+import { parse } from "https://unpkg.com/opentype.js/dist/opentype.module.mjs";
 parse(...);
 </script>
 ```

--- a/docs/examples/creating-fonts.html
+++ b/docs/examples/creating-fonts.html
@@ -44,7 +44,7 @@
 </form>
 
 <script type="module">
-    import * as opentype from "/dist/opentype.module.js";
+    import * as opentype from "/dist/opentype.module.mjs";
     function hexDump(bytes) {
         var hexString = bytes.map(function(v) {
             var h = v.toString(16);

--- a/docs/examples/font-editor.html
+++ b/docs/examples/font-editor.html
@@ -174,7 +174,7 @@ accent: rgb(26, 70, 102);
 
 <textarea id="code"></textarea>
 <script type="module">
-import * as opentype from "/dist/opentype.module.js";
+import * as opentype from "/dist/opentype.module.mjs";
 
 function linePoint(t, x1, y1, x2, y2) {
     return [x1 + t * (x2 - x1),

--- a/docs/examples/reading-writing.html
+++ b/docs/examples/reading-writing.html
@@ -42,7 +42,7 @@
 </form>
 
 <script type="module">
-import * as opentype from "/dist/opentype.module.js";
+import * as opentype from "/dist/opentype.module.mjs";
 
 // Create a canvas and adds it to the document.
 // Returns the 2d drawing context.

--- a/docs/font-inspector.html
+++ b/docs/font-inspector.html
@@ -91,7 +91,7 @@
 
 
 <script type="module">
-import * as opentype from "/dist/opentype.module.js";
+import * as opentype from "/dist/opentype.module.mjs";
 
 var font = null;
 const fontSize = 32;

--- a/docs/glyph-inspector.html
+++ b/docs/glyph-inspector.html
@@ -58,7 +58,7 @@
 
 
 <script type="module">
-import * as opentype from "/dist/opentype.module.js";
+import * as opentype from "/dist/opentype.module.mjs";
 
 const form = document.forms.demo;
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,7 +73,7 @@
 
 
 <script type="module">
-import * as opentype from "/dist/opentype.module.js";
+import * as opentype from "/dist/opentype.module.mjs";
 
 const form = document.forms.demo;
 form.oninput = renderText;

--- a/docs/module.html
+++ b/docs/module.html
@@ -1,4 +1,4 @@
 <script type="module">
-    import * as ot from '/dist/opentype.module.js';
+    import * as ot from '/dist/opentype.module.mjs';
     console.log(ot)
 </script>

--- a/package.json
+++ b/package.json
@@ -22,18 +22,18 @@
   },
   "main": "./dist/opentype.js",
   "browser": "./dist/opentype.js",
-  "module": "./dist/opentype.module.js",
+  "module": "./dist/opentype.module.mjs",
   "scripts": {
     "build": "npm run b:umd && npm run b:esm",
     "dist": " npm run d:umd && npm run d:esm",
     "test": "npm run build && npm run dist && mocha --require reify --recursive && npm run lint",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",
-    "start": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=esm  --out-extension:.js=.module.js --global-name=opentype --footer:js=\"(function (root, factory) { if (typeof define === 'function' && define.amd)define(factory); else if (typeof module === 'object' && module.exports)module.exports = factory(); else root.opentype = factory(); }(typeof self !== 'undefined' ? self : this, () => ({...opentype,'default':opentype})));\" --watch --servedir=. --footer:js=\"new EventSource('/esbuild').addEventListener('change', () => location.reload())\"",
-    "b:umd": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=iife --out-extension:.js=.js        --global-name=opentype --footer:js=\"(function (root, factory) { if (typeof define === 'function' && define.amd)define(factory); else if (typeof module === 'object' && module.exports)module.exports = factory(); else root.opentype = factory(); }(typeof self !== 'undefined' ? self : this, () => ({...opentype,'default':opentype})));\"",
-    "d:umd": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=iife --out-extension:.js=.min.js    --global-name=opentype --footer:js=\"(function (root, factory) { if (typeof define === 'function' && define.amd)define(factory); else if (typeof module === 'object' && module.exports)module.exports = factory(); else root.opentype = factory(); }(typeof self !== 'undefined' ? self : this, () => ({...opentype,'default':opentype})));\" --minify --sourcemap",
-    "b:esm": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=esm  --out-extension:.js=.module.js",
-    "d:esm": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=esm  --out-extension:.js=.module.min.js --minify --sourcemap"
+    "start": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=esm  --out-extension:.js=.module.mjs --global-name=opentype --footer:js=\"(function (root, factory) { if (typeof define === 'function' && define.amd)define(factory); else if (typeof module === 'object' && module.exports)module.exports = factory(); else root.opentype = factory(); }(typeof self !== 'undefined' ? self : this, () => ({...opentype,'default':opentype})));\" --watch --servedir=. --footer:js=\"new EventSource('/esbuild').addEventListener('change', () => location.reload())\"",
+    "b:umd": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=iife --out-extension:.js=.js         --global-name=opentype --footer:js=\"(function (root, factory) { if (typeof define === 'function' && define.amd)define(factory); else if (typeof module === 'object' && module.exports)module.exports = factory(); else root.opentype = factory(); }(typeof self !== 'undefined' ? self : this, () => ({...opentype,'default':opentype})));\"",
+    "d:umd": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=iife --out-extension:.js=.min.js     --global-name=opentype --footer:js=\"(function (root, factory) { if (typeof define === 'function' && define.amd)define(factory); else if (typeof module === 'object' && module.exports)module.exports = factory(); else root.opentype = factory(); }(typeof self !== 'undefined' ? self : this, () => ({...opentype,'default':opentype})));\" --minify --sourcemap",
+    "b:esm": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=esm  --out-extension:.js=.module.mjs",
+    "d:esm": "esbuild --bundle src/opentype.js --outdir=dist --external:fs --external:http --external:https --target=es2018 --format=esm  --out-extension:.js=.module.min.mjs --minify --sourcemap"
   },
   "devDependencies": {
     "mocha": "^8.4.0",

--- a/test/distSpec.js
+++ b/test/distSpec.js
@@ -1,16 +1,16 @@
 import assert from 'assert';
 import { parse as parseBuffer } from '../dist/opentype.js';
 import { parse as parseBufferMin } from '../dist/opentype.min.js';
-import { parse as parseBufferMod } from '../dist/opentype.module.js';
-import { parse as parseBufferModMin } from '../dist/opentype.module.min.js';
+import { parse as parseBufferMod } from '../dist/opentype.module.mjs';
+import { parse as parseBufferModMin } from '../dist/opentype.module.min.mjs';
 import { readFileSync } from 'fs';
 
 describe('opentype.js dist', function () {
     const dist_matrix = [
         [parseBuffer, '.js'],
         [parseBufferMin, '.min.js'],
-        [parseBufferMod, '.module.js'],
-        [parseBufferModMin, '.module.min.js'],
+        [parseBufferMod, '.module.mjs'],
+        [parseBufferModMin, '.module.min.mjs'],
     ]
 
     for (const [parse, ext] of dist_matrix) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Change the output file for ESM to have an `.mjs` file extension. NodeJS says that it recognizes `.mjs` extensions as modules. This will help since `type` is not set in `package.json`. 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

I ran into an issue where the only fix was renaming the output module file.
I'm using typescript, vite, vitest and pandacss. While vitest and typescript understand that `.module.js` is ESM, it seems like pandacss is relying on node and it thinks it's `commonjs`. 

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
