### PR TITLE
chore(deps): move eslint-plugin-local-rules to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,6 @@
     "": {
       "name": "opentype.js",
       "license": "MIT",
-      "dependencies": {
-        "eslint-plugin-local-rules": "^2.0.1"
-      },
       "bin": {
         "ot": "bin/ot"
       },
@@ -16,6 +13,7 @@
         "esbuild": "^0.20.0",
         "eslint": "^8.56.0",
         "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-local-rules": "^2.0.1",
         "mocha": "^8.4.0",
         "reify": "^0.20.12"
       }
@@ -1334,7 +1332,8 @@
     "node_modules/eslint-plugin-local-rules": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-2.0.1.tgz",
-      "integrity": "sha512-AJhGd+GcI5r2dbjiGPixM8jnBl0XFxqoVbqzwKbYz+nTk+Cj5dNE3+OlhC176bl5r25KsGsIthLi1VqIW5Ga+A=="
+      "integrity": "sha512-AJhGd+GcI5r2dbjiGPixM8jnBl0XFxqoVbqzwKbYz+nTk+Cj5dNE3+OlhC176bl5r25KsGsIthLi1VqIW5Ga+A==",
+      "dev": true
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
@@ -4272,7 +4271,8 @@
     "eslint-plugin-local-rules": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-2.0.1.tgz",
-      "integrity": "sha512-AJhGd+GcI5r2dbjiGPixM8jnBl0XFxqoVbqzwKbYz+nTk+Cj5dNE3+OlhC176bl5r25KsGsIthLi1VqIW5Ga+A=="
+      "integrity": "sha512-AJhGd+GcI5r2dbjiGPixM8jnBl0XFxqoVbqzwKbYz+nTk+Cj5dNE3+OlhC176bl5r25KsGsIthLi1VqIW5Ga+A==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "esbuild": "^0.20.0",
     "eslint": "^8.56.0",
     "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-local-rules": "^2.0.1",
     "reify": "^0.20.12"
   },
   "bin": {
@@ -90,8 +91,5 @@
       "local-rules/ban-foreach": 2,
       "local-rules/import-extensions": 2
     }
-  },
-  "dependencies": {
-    "eslint-plugin-local-rules": "^2.0.1"
   }
 }


### PR DESCRIPTION
move eslint-plugin-local-rules to devDependencies

## Description
move eslint-plugin-local-rules to devDependencies

## Motivation and Context

When I checked the dependency graph of my plugins, I found that opentype.js depends on eslint-plugin-local-rules, but it is not used in the production environment.

![image](https://github.com/opentypejs/opentype.js/assets/68177907/1f19e24e-6713-4b0f-8cbd-a9e13345fc9f)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did `npm run test` and all tests passed green. 
And I checked the source code and did not find a reference to eslint-plugin-local-rules.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
