### PR TITLE
Font is treated as a required argument

### DIFF
--- a/src/glyph.mjs
+++ b/src/glyph.mjs
@@ -357,7 +357,7 @@ Glyph.prototype.getMetrics = function() {
  * @param  {opentype.Font} font - if hinting is to be used, or CPAL/COLR / variation needs to be rendered, the font
  */
 Glyph.prototype.draw = function(ctx, x, y, fontSize, options, font) {
-    options = Object.assign({}, font.defaultRenderOptions, options);
+    options = Object.assign({}, font && font.defaultRenderOptions, options);
     const path = this.getPath(x, y, fontSize, options, font);
     path.draw(ctx);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This makes it so font is not treated as a required argument in `Glyph.draw`.

## Motivation and Context
This looks like a simple regression bug.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
