### PR TITLE
Fixed error running `get` with `null` index to resolve `charToGlyph` bug per #735

### DIFF
--- a/src/glyphset.mjs
+++ b/src/glyphset.mjs
@@ -66,7 +66,7 @@ if(typeof Symbol !== 'undefined' && Symbol.iterator) {
  */
 GlyphSet.prototype.get = function(index) {
     // this.glyphs[index] is 'undefined' when low memory mode is on. glyph is pushed on request only.
-    if (this.glyphs[index] === undefined) {
+    if (this.glyphs[index] === undefined && typeof index === 'number') {
         this.font._push(index);
         if (typeof this.glyphs[index] === 'function') {
             this.glyphs[index] = this.glyphs[index]();

--- a/test/opentype.spec.mjs
+++ b/test/opentype.spec.mjs
@@ -174,6 +174,23 @@ describe('opentype.js on low memory mode', function() {
         assert.equal(ndGlyph.unicode, undefined);
     });
 
+    it('should return .notdef when looking up non-existent glyph in user-created font', function() {
+        const nullGlyph = new Glyph({
+            name: '.notdef',
+            path: new Path()
+        });
+        const font = new Font({
+            familyName: 'TestFont',
+            styleName: 'Medium',
+            unitsPerEm: 1000,
+            ascender: 800,
+            descender: -200,
+            glyphs: [nullGlyph]
+        });
+        const ndGlyph = font.charToGlyph('B');
+        assert.equal(ndGlyph.name, '.notdef');
+    });
+
     it('should correctly set unicode 0 for .null glyph', function() {
         const nullGlyph = new Glyph({
             name: '.null',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change prevents an error when the `GlyphSet` `get` method is called with an `index` of `null`/`undefined`.  This resolves a bug with `charToGlyph` described in #735.  A test is also added to prevent the bug from re-occurring in the future. 

## Motivation and Context
See #735.  In short, when using `charToGlyph` with (1) a `Font` object created by opentype.js and (2) a character that has no glyph in the file, an error is thrown.  This occurs because opentype.js runs `this.glyphs.get(glyphIndex)` where `glyphIndex` is `null`.

This simple change fixes this bug, and makes `get` return `undefined` if the glyph does not exist.  Looking at the code in `charToGlyph` (linked below), this is the behavior that is expected by that function.

https://github.com/opentypejs/opentype.js/blob/e9c090ed801f74df2cedc2f1df937bd439070960/src/font.mjs#L201-L210

After the change, running `charToGlyph` with a `Font` object created by opentype.js defaults to returning `.notdef`, which is consistent with the behavior when using an imported font. 

## How Has This Been Tested?
This fixed the issue described in #735 in my project.  The existing automated tests pass, and I added a new automated test for the bug this solves.  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
