### PR TITLE
Fix PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,4 +27,4 @@
 - [ ] I have added tests to cover my changes.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the **README** accordingly.
-- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have read the **Contribute** README section.


### PR DESCRIPTION
The PR template currently requests that developers affirm that "I have read the **CONTRIBUTING** document."  However, this document appears to have been deleted in [this commit](https://github.com/opentypejs/opentype.js/commit/071bd051b2e3f495e2a9a9e062c1f0ff1684d7f0).  This PR updates the language to avoid confusion.