### PR TITLE
Fixed gasp support bugs per #738

### DIFF
--- a/src/opentype.mjs
+++ b/src/opentype.mjs
@@ -310,8 +310,13 @@ function parseBuffer(buffer, opt={}) {
                 metaTableEntry = tableEntry;
                 break;
             case 'gasp':
-                table = uncompressTable(data, tableEntry);
-                font.tables.gasp = gasp.parse(table.data, table.offset);
+                try {
+                    table = uncompressTable(data, tableEntry);
+                    font.tables.gasp = gasp.parse(table.data, table.offset);
+                } catch (e) {
+                    console.warn('Failed to parse gasp table, skipping.');
+                    console.warn(e);
+                }
                 break;
             case 'SVG ':
                 table = uncompressTable(data, tableEntry);

--- a/src/tables/gasp.mjs
+++ b/src/tables/gasp.mjs
@@ -34,9 +34,9 @@ function makeGaspTable(gasp) {
         {name: 'numRanges', type: 'USHORT', value: gasp.numRanges},
     ]);
 
-    for (let i in gasp.numRanges) {
-        result.fields.push({name: 'rangeMaxPPEM', type: 'USHORT', value: gasp.numRanges[i].rangeMaxPPEM});
-        result.fields.push({name: 'rangeGaspBehavior', type: 'USHORT', value: gasp.numRanges[i].rangeGaspBehavior});
+    for (let i in gasp.gaspRanges) {
+        result.fields.push({name: 'rangeMaxPPEM', type: 'USHORT', value: gasp.gaspRanges[i].rangeMaxPPEM});
+        result.fields.push({name: 'rangeGaspBehavior', type: 'USHORT', value: gasp.gaspRanges[i].rangeGaspBehavior});
     }
 
     return result;

--- a/test/tables/gasp.spec.mjs
+++ b/test/tables/gasp.spec.mjs
@@ -31,7 +31,7 @@ describe('tables/gasp.mjs', function () {
 
     it('can write tables that are read as identical to the original', function() {
         const font2 = parse(font.toArrayBuffer());
-        assert.strictEqual(JSON.stringify(font.tables.gasp), JSON.stringify(font2.tables.gasp));
+        assert.deepStrictEqual(font.tables.gasp, font2.tables.gasp);
     });
 
 });

--- a/test/tables/gasp.spec.mjs
+++ b/test/tables/gasp.spec.mjs
@@ -29,4 +29,9 @@ describe('tables/gasp.mjs', function () {
         assert.equal(font.tables.gasp.gaspRanges[1].rangeGaspBehavior, 0x0001 + 0x0002 + 0x0004 + 0x0008); // all flags set = 15
     });
 
+    it('can write tables that are read as identical to the original', function() {
+        const font2 = parse(font.toArrayBuffer());
+        assert.strictEqual(JSON.stringify(font.tables.gasp), JSON.stringify(font2.tables.gasp));
+    });
+
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Context
See #738.  In short, write support for the `gasp` table was implemented recently in #595, however is broken.  Any font written by opentype.js that includes a `gasp` table cannot be re-imported by opentype.js.  

## Changes
This PR makes two changes to resolve.  First, it fixes the typo in the `gasp` write function, which was trying to iterate over the integer `gasp.numRanges` rather than the array `gasp.gaspRanges`.  Second, it wraps the entire `gasp` read function in a `try` block.  This should prevent any future issues where failing to parse this optional table prevents a font from being read.  

## How Has This Been Tested?
I confirmed that the [Changa-Regular.ttf](https://github.com/opentypejs/opentype.js/blob/master/test/fonts/Changa-Regular.ttf) font could be saved/read using `toArrayBuffer`/`opentype.parse`, which (as described in #738) previously resulted in an error.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **Contribute** README section.
