### PR TITLE
GlyphSet.prototype.get can return undefined

### DIFF
--- a/src/glyphset.mjs
+++ b/src/glyphset.mjs
@@ -66,11 +66,7 @@ if(typeof Symbol !== 'undefined' && Symbol.iterator) {
  */
 GlyphSet.prototype.get = function(index) {
     // this.glyphs[index] is 'undefined' when low memory mode is on. glyph is pushed on request only.
-    if (this.glyphs[index] === undefined) {
-        if (!this.font._push) {
-            // When not in low memory mode, the index is out of bounds
-            return undefined;
-        }
+    if (this.font._push && this.glyphs[index] === undefined) {
         this.font._push(index);
         if (typeof this.glyphs[index] === 'function') {
             this.glyphs[index] = this.glyphs[index]();

--- a/src/glyphset.mjs
+++ b/src/glyphset.mjs
@@ -62,11 +62,15 @@ if(typeof Symbol !== 'undefined' && Symbol.iterator) {
 
 /**
  * @param  {number} index
- * @return {opentype.Glyph}
+ * @return {opentype.Glyph | undefined}
  */
 GlyphSet.prototype.get = function(index) {
     // this.glyphs[index] is 'undefined' when low memory mode is on. glyph is pushed on request only.
     if (this.glyphs[index] === undefined) {
+        if (!this.font._push) {
+            // When not in low memory mode, the index is out of bounds
+            return undefined;
+        }
         this.font._push(index);
         if (typeof this.glyphs[index] === 'function') {
             this.glyphs[index] = this.glyphs[index]();


### PR DESCRIPTION
Calling `font.glyphs.get(9999)` should return `undefined` if the glyph doesn't exist.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When not in low memory mode, `font.glyphs.get(9999)` errors because `font._push` is undefined.