### PR TITLE
Bug fix for #757 - write all name table entries for fonts crafted from scratch

### DIFF
--- a/src/tables/sfnt.mjs
+++ b/src/tables/sfnt.mjs
@@ -292,16 +292,16 @@ function fontToSfntTable(font) {
     const fontNamesWindows = font.names.windows || {};
 
     // do this as a loop to reduce redundant code
-    for (const platform in ['unicode', 'macintosh', 'windows']) {
+    for (const platform in names) {
 
         names[platform] = names[platform] || {};
 
         if (!names[platform].uniqueID) {
-            names.unicode.uniqueID = {en: font.getEnglishName('manufacturer') + ':' + englishFullName};
+            names[platform].uniqueID = {en: font.getEnglishName('manufacturer') + ':' + englishFullName};
         }
 
         if (!names[platform].postScriptName) {
-            names.unicode.postScriptName = {en: postScriptName};
+            names[platform].postScriptName = {en: postScriptName};
         }
     }
 

--- a/src/tables/sfnt.mjs
+++ b/src/tables/sfnt.mjs
@@ -297,7 +297,8 @@ function fontToSfntTable(font) {
         names[platform] = names[platform] || {};
 
         if (!names[platform].uniqueID) {
-            names[platform].uniqueID = {en: font.getEnglishName('manufacturer') + ':' + englishFullName};
+            const manufacturer = font.getEnglishName('manufacturer') || '';
+            names[platform].uniqueID = { en: `${manufacturer}: ${englishFullName}` };
         }
 
         if (!names[platform].postScriptName) {

--- a/test/tables/sfnt.spec.mjs
+++ b/test/tables/sfnt.spec.mjs
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import Font from '../../src/font.mjs';
-import sfnt from '../../src/tables/sfnt.mjs';
 import name from '../../src/tables/name.mjs';
+import sfnt from '../../src/tables/sfnt.mjs';
 import { encode } from '../../src/types.mjs';
 
 function encodeAndParseTable(table, parser) {
@@ -60,7 +60,8 @@ describe('tables/sfnt.mjs', function () {
                     license: { en: ' ' },
                     licenseURL: { en: ' ' },
                     preferredFamily: { en: defaultFont.familyName }, // 'MyFont'
-                    preferredSubfamily: { en: defaultFont.styleName } // 'Medium'
+                    preferredSubfamily: { en: defaultFont.styleName }, // 'Medium'
+                    uniqueID: { en: ` : ${defaultFont.familyName} ${defaultFont.styleName}` },
                 },
                 windows: {
                     copyright: { en: ' ' },
@@ -78,7 +79,8 @@ describe('tables/sfnt.mjs', function () {
                     license: { en: ' ' },
                     licenseURL: { en: ' ' },
                     preferredFamily: { en: defaultFont.familyName }, // 'MyFont'
-                    preferredSubfamily: { en: defaultFont.styleName } // 'Medium'
+                    preferredSubfamily: { en: defaultFont.styleName }, // 'Medium'
+                    uniqueID: { en: ` : ${defaultFont.familyName} ${defaultFont.styleName}` },
                 }
             });
         });
@@ -121,7 +123,9 @@ describe('tables/sfnt.mjs', function () {
                     fullName: { en: fullName },
                     version: { en: version },
                     preferredFamily: { en: preferredFamily },
-                    preferredSubfamily: { en: preferredSubfamily}
+                    preferredSubfamily: { en: preferredSubfamily },
+                    postScriptName: { en: `${fontFamily.replaceAll(' ', '')}-${fontSubfamily}` },
+                    uniqueID: { en: `: ${fontFamily} ${fontSubfamily}` },
                 },
                 windows: {
                     fontFamily: { en: fontFamily },
@@ -129,7 +133,9 @@ describe('tables/sfnt.mjs', function () {
                     fullName: { en: fullName },
                     version: { en: version },
                     preferredFamily: { en: preferredFamily },
-                    preferredSubfamily: { en: preferredSubfamily}
+                    preferredSubfamily: { en: preferredSubfamily},
+                    postScriptName: { en: `${fontFamily.replaceAll(' ', '')}-${fontSubfamily}` },
+                    uniqueID: { en: `: ${fontFamily} ${fontSubfamily}` },
                 }
             });
         });


### PR DESCRIPTION
## Description
Due to a change in 858a5d2, fonts that are created from scratch are not generating two default name table entries, which is causing fonts to be un-openable in Windows.

Lots of details captured in #757 - but here is a quick overview of the bug. The bug that was causing issues for two reasons:

1) the `for... in` loop is looping over the keys of the array, `0, 1, 2` as opposed to the values of the array (which looks like what was intended).
2) If an empty value is found, the `unicode` value is updated as opposed to whatever platform is currently being looped over.


## Motivation and Context
Any font object generated programmatically would successfully export, but the font file itself would not be able to be opened. In Windows the "This is not a valid font file" dialog would be shown.

## How Has This Been Tested?
Lots of tests explained in #757 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **Contribute** README section.
