### PR TITLE
os2: Fill Panose when writing font

### DIFF
--- a/src/tables/os2.mjs
+++ b/src/tables/os2.mjs
@@ -165,6 +165,16 @@ function parseOS2Table(data, start) {
     for (let i = 0; i < 10; i++) {
         os2.panose[i] = p.parseByte();
     }
+    os2.bFamilyType = os2.panose[0];
+    os2.bSerifStyle = os2.panose[1];
+    os2.bWeight = os2.panose[2];
+    os2.bProportion = os2.panose[3];
+    os2.bContrast = os2.panose[4];
+    os2.bStrokeVariation = os2.panose[5];
+    os2.bArmStyle = os2.panose[6];
+    os2.bLetterform = os2.panose[7];
+    os2.bMidline = os2.panose[8];
+    os2.bXHeight = os2.panose[9];
 
     os2.ulUnicodeRange1 = p.parseULong();
     os2.ulUnicodeRange2 = p.parseULong();


### PR DESCRIPTION
Parsing a font from a buffer and writing it back to a buffer changes all Panose values to zero.
This PR fixes this.

## Description

**[why]**
When an existing font file is read from a buffer and then written back into a buffer all Panose values will be zero.

The problem has been most likly been introduced with PR #630 (but I did not check that).

There are two disjunct data structures in the font.tables.os2 object that describe the panose values:
* An array with the Panose values `.panose = [ 1, 2, ...]`
* Dedicated properties for each Panose value e.g. `.bFamilyType`

The aforementioned PR seems to address only fonts created from scratch and not parsed from a buffer.

Writing out the font into a buffer will always use the dedicated Panose properties and ignore the .panose array.

Parsing a font does set the array but not the dedicated properties. They are not even existing then.

**[how]**
When an existing font is parsed the `.panose` array is filled (as before). But now the dedicated properties are also created and filled with the individual values.

**[note]**
The written font is always using the dedicated values. If a user changes the panose array that will have no effect. There are no checks if the data is consistent. Having the same data in two disjunct structures is not so nice to handle.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual tests with ttx ;)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **Contribute** README section.
