### PR TITLE
Suggest using `itskyedo/woff2-encoder` instead of `fontello/wawoff2` for decompressing woff2 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ import decompress from 'woff2-encoder/decompress';
 const woff2Buffer = await fetch('/fonts/my.woff2').then(r => r.arrayBuffer());
 const { buffer } = await decompress(woff2Buffer);
 const font = parse(buffer);
-//    👆🏼 { supported: true ,glyphs: {…} ,encoding: {…} ,position: {…} ,substitution: {…} , … }
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -109,24 +109,15 @@ buffer.then(data => {
 WOFF2 Brotli compression perform [29% better](https://www.w3.org/TR/WOFF20ER/#appendixB) than it WOFF predecessor.
 But this compression is also more complex, and would result in a much heavier (&gt;10×!) opentype.js library (≈120KB => ≈1400KB).
 
-To solve this: Decompress the font beforehand (for example with [fontello/wawoff2](https://github.com/fontello/wawoff2)).
+To solve this: Decompress the font beforehand (for example with [itskyedo/woff2-encoder](https://github.com/itskyedo/woff2-encoder)).
 
-```js
-// promise-based utility to load libraries using the good old <script> tag
-const loadScript = (src) => new Promise((onload) => document.documentElement.append(
-  Object.assign(document.createElement('script'), {src, onload})
-));
+```jsimport { parse } from 'opentype.js';
+import decompress from 'woff2-encoder/decompress';
 
-const buffer = //...same as previous example...
-
-// load wawoff2 if needed, and wait (!) for it to be ready
-if (!window.Module) {
-  const path = 'https://unpkg.com/wawoff2@2.0.1/build/decompress_binding.js'
-  const init = new Promise((done) => window.Module = { onRuntimeInitialized: done});
-  await loadScript(path).then(() => init);
-}
-// decompress before parsing
-const font = opentype.parse(Module.decompress(await buffer));
+const woff2Buffer = await fetch('/fonts/my.woff2').then(r => r.arrayBuffer());
+const { buffer } = await decompress(woff2Buffer);
+const font = parse(buffer);
+//    👆🏼 { supported: true ,glyphs: {…} ,encoding: {…} ,position: {…} ,substitution: {…} , … }
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ But this compression is also more complex, and would result in a much heavier (&
 
 To solve this: Decompress the font beforehand (for example with [itskyedo/woff2-encoder](https://github.com/itskyedo/woff2-encoder)).
 
-```jsimport { parse } from 'opentype.js';
+```js
+import { parse } from 'opentype.js';
 import decompress from 'woff2-encoder/decompress';
 
 const woff2Buffer = await fetch('/fonts/my.woff2').then(r => r.arrayBuffer());


### PR DESCRIPTION
## Description
Updating the README to suggest to use [itskyedo/woff2-encoder](https://github.com/itskyedo/woff2-encoder) instead of [fontello/wawoff2](https://github.com/fontello/wawoff2) for decompressing and parsing woff2 font files. I also chose to dramatically simplify the example code, since I found it hard to follow for just a simple example.

## Motivation and Context
Since I spend a good chunk of yesterday trying to get `fontello/wawoff2` (and similar libraries) working without luck in modern browsers, I wanted to share the library that finally "just worked" for me.

## How Has This Been Tested?
Here is a JSREPL demonstrating that the example code works: https://jsrepl.io/repl/vcqrshb69b0

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Readme update

## Checklist:
- [ ] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the **README** accordingly.
- [ ] I have read the **Contribute** README section.
