### PR TITLE
Add support for chaining and context substitution tables

### DIFF
--- a/src/features/applySubstitution.mjs
+++ b/src/features/applySubstitution.mjs
@@ -65,9 +65,12 @@ function ligatureSubstitutionFormat1(action, tokens, index) {
 const SUBSTITUTIONS = {
     11: singleSubstitutionFormat1,
     12: singleSubstitutionFormat2,
+    61: chainingSubstitutionFormat3,
+    62: chainingSubstitutionFormat3,
     63: chainingSubstitutionFormat3,
     41: ligatureSubstitutionFormat1,
     51: chainingSubstitutionFormat3,
+    52: chainingSubstitutionFormat3,
     53: chainingSubstitutionFormat3
 };
 

--- a/src/features/featureQuery.mjs
+++ b/src/features/featureQuery.mjs
@@ -101,6 +101,265 @@ function lookupCoverageList(coverageList, contextParams) {
 }
 
 /**
+ * Handle chaining context substitution - format 1 (glyph-based)
+ * @param {ContextParams} contextParams context params to lookup
+ * @param {object} subtable the subtable containing chain rule sets
+ */
+function chainingSubstitutionFormat1(contextParams, subtable) {
+    // Get the current glyph and check if it's in the coverage
+    let glyphIndex = contextParams.current;
+    glyphIndex = Array.isArray(glyphIndex) ? glyphIndex[0] : glyphIndex;
+    const coverageIndex = lookupCoverage(glyphIndex, subtable.coverage);
+    if (coverageIndex === -1) return [];
+
+    // Get the chain rule set for this coverage index
+    const chainRuleSet = subtable.chainRuleSets[coverageIndex];
+    if (!chainRuleSet) return [];
+
+    // Try each rule in the set
+    for (let r = 0; r < chainRuleSet.length; r++) {
+        const rule = chainRuleSet[r];
+
+        // Check backtrack glyphs (in reverse order)
+        let backtrackMatch = true;
+        const backtrackContext = [].concat(contextParams.backtrack);
+        backtrackContext.reverse();
+        // Skip tashkeel (Arabic diacritics)
+        while (backtrackContext.length && isTashkeelArabicChar(backtrackContext[0].char)) {
+            backtrackContext.shift();
+        }
+        if (backtrackContext.length < rule.backtrack.length) {
+            backtrackMatch = false;
+        } else {
+            for (let b = 0; b < rule.backtrack.length; b++) {
+                const backGlyphIndex = backtrackContext[b];
+                if (backGlyphIndex !== rule.backtrack[b]) {
+                    backtrackMatch = false;
+                    break;
+                }
+            }
+        }
+        if (!backtrackMatch) continue;
+
+        // Check input glyphs (starting from second glyph, first is already matched via coverage)
+        let inputMatch = true;
+        for (let i = 0; i < rule.input.length; i++) {
+            const inputGlyphIndex = contextParams.lookahead[i];
+            if (inputGlyphIndex === undefined || inputGlyphIndex !== rule.input[i]) {
+                inputMatch = false;
+                break;
+            }
+        }
+        if (!inputMatch) continue;
+
+        // Check lookahead glyphs
+        let lookaheadMatch = true;
+        const lookaheadOffset = rule.input.length;
+        let lookaheadContext = contextParams.lookahead.slice(lookaheadOffset);
+        // Skip tashkeel in lookahead
+        while (lookaheadContext.length && isTashkeelArabicChar(lookaheadContext[0].char)) {
+            lookaheadContext.shift();
+        }
+        if (lookaheadContext.length < rule.lookahead.length) {
+            lookaheadMatch = false;
+        } else {
+            for (let l = 0; l < rule.lookahead.length; l++) {
+                if (lookaheadContext[l] !== rule.lookahead[l]) {
+                    lookaheadMatch = false;
+                    break;
+                }
+            }
+        }
+        if (!lookaheadMatch) continue;
+
+        // All context matches! Apply the lookup records
+        let substitutions = [];
+        for (let i = 0; i < rule.lookupRecords.length; i++) {
+            const lookupRecord = rule.lookupRecords[i];
+            const lookupListIndex = lookupRecord.lookupListIndex;
+            const lookupTable = this.getLookupByIndex(lookupListIndex);
+
+            for (let s = 0; s < lookupTable.subtables.length; s++) {
+                let lookupSubtable = lookupTable.subtables[s];
+                let lookup;
+                let substitutionType = this.getSubstitutionType(
+                    lookupTable,
+                    lookupSubtable,
+                );
+
+                if (substitutionType === '71') {
+                    // Extension subtable
+                    substitutionType = this.getSubstitutionType(
+                        lookupSubtable,
+                        lookupSubtable.extension,
+                    );
+                    lookup = this.getLookupMethod(
+                        lookupSubtable,
+                        lookupSubtable.extension,
+                    );
+                    lookupSubtable = lookupSubtable.extension;
+                } else {
+                    lookup = this.getLookupMethod(lookupTable, lookupSubtable);
+                }
+
+                // Get the glyph at the sequence index
+                const seqIndex = lookupRecord.sequenceIndex;
+                const targetGlyph = seqIndex === 0 ? glyphIndex : contextParams.lookahead[seqIndex - 1];
+
+                if (substitutionType === '11' || substitutionType === '12') {
+                    const substitution = lookup(targetGlyph);
+                    if (substitution) substitutions.push(substitution);
+                }
+            }
+        }
+        return substitutions;
+    }
+
+    return [];
+}
+
+/**
+ * Handle chaining context substitution - format 2 (class-based)
+ * @param {ContextParams} contextParams context params to lookup
+ * @param {object} subtable the subtable containing class definitions
+ */
+function chainingSubstitutionFormat2(contextParams, subtable) {
+    // Get the current glyph and check if it's in the coverage
+    let glyphIndex = contextParams.current;
+    glyphIndex = Array.isArray(glyphIndex) ? glyphIndex[0] : glyphIndex;
+    const coverageIndex = lookupCoverage(glyphIndex, subtable.coverage);
+    if (coverageIndex === -1) return [];
+
+    // Get the class of the current glyph using the input class definition
+    const inputClass = this.font.substitution.getGlyphClass(
+        subtable.inputClassDef,
+        glyphIndex,
+    );
+
+    // Get the chain class set for this class (may be null for unused classes)
+    const chainClassSet = subtable.chainClassSet[inputClass];
+    if (!chainClassSet) return [];
+
+    // Try each rule in the class set
+    for (let r = 0; r < chainClassSet.length; r++) {
+        const rule = chainClassSet[r];
+
+        // Check backtrack classes (in reverse order)
+        let backtrackMatch = true;
+        const backtrackContext = [].concat(contextParams.backtrack);
+        backtrackContext.reverse();
+        // Skip tashkeel (Arabic diacritics)
+        while (backtrackContext.length && isTashkeelArabicChar(backtrackContext[0].char)) {
+            backtrackContext.shift();
+        }
+        if (backtrackContext.length < rule.backtrack.length) {
+            backtrackMatch = false;
+        } else {
+            for (let b = 0; b < rule.backtrack.length; b++) {
+                const backGlyphIndex = backtrackContext[b];
+                const backClass = this.font.substitution.getGlyphClass(
+                    subtable.backtrackClassDef,
+                    backGlyphIndex,
+                );
+                if (backClass !== rule.backtrack[b]) {
+                    backtrackMatch = false;
+                    break;
+                }
+            }
+        }
+        if (!backtrackMatch) continue;
+
+        // Check input classes (starting from second glyph, first is already matched via coverage)
+        let inputMatch = true;
+        for (let i = 0; i < rule.input.length; i++) {
+            const inputGlyphIndex = contextParams.lookahead[i];
+            if (inputGlyphIndex === undefined) {
+                inputMatch = false;
+                break;
+            }
+            const inClass = this.font.substitution.getGlyphClass(
+                subtable.inputClassDef,
+                inputGlyphIndex,
+            );
+            if (inClass !== rule.input[i]) {
+                inputMatch = false;
+                break;
+            }
+        }
+        if (!inputMatch) continue;
+
+        // Check lookahead classes
+        let lookaheadMatch = true;
+        const lookaheadOffset = rule.input.length;
+        // Skip tashkeel in lookahead
+        let lookaheadContext = contextParams.lookahead.slice(lookaheadOffset);
+        while (lookaheadContext.length && isTashkeelArabicChar(lookaheadContext[0].char)) {
+            lookaheadContext.shift();
+        }
+        if (lookaheadContext.length < rule.lookahead.length) {
+            lookaheadMatch = false;
+        } else {
+            for (let l = 0; l < rule.lookahead.length; l++) {
+                const lookGlyphIndex = lookaheadContext[l];
+                const lookClass = this.font.substitution.getGlyphClass(
+                    subtable.lookaheadClassDef,
+                    lookGlyphIndex,
+                );
+                if (lookClass !== rule.lookahead[l]) {
+                    lookaheadMatch = false;
+                    break;
+                }
+            }
+        }
+        if (!lookaheadMatch) continue;
+
+        // All context matches! Apply the lookup records
+        let substitutions = [];
+        for (let i = 0; i < rule.lookupRecords.length; i++) {
+            const lookupRecord = rule.lookupRecords[i];
+            const lookupListIndex = lookupRecord.lookupListIndex;
+            const lookupTable = this.getLookupByIndex(lookupListIndex);
+
+            for (let s = 0; s < lookupTable.subtables.length; s++) {
+                let lookupSubtable = lookupTable.subtables[s];
+                let lookup;
+                let substitutionType = this.getSubstitutionType(
+                    lookupTable,
+                    lookupSubtable,
+                );
+
+                if (substitutionType === '71') {
+                    // Extension subtable
+                    substitutionType = this.getSubstitutionType(
+                        lookupSubtable,
+                        lookupSubtable.extension,
+                    );
+                    lookup = this.getLookupMethod(
+                        lookupSubtable,
+                        lookupSubtable.extension,
+                    );
+                    lookupSubtable = lookupSubtable.extension;
+                } else {
+                    lookup = this.getLookupMethod(lookupTable, lookupSubtable);
+                }
+
+                // Get the glyph at the sequence index
+                const seqIndex = lookupRecord.sequenceIndex;
+                const targetGlyph = seqIndex === 0 ? glyphIndex : contextParams.lookahead[seqIndex - 1];
+
+                if (substitutionType === '11' || substitutionType === '12') {
+                    const substitution = lookup(targetGlyph);
+                    if (substitution) substitutions.push(substitution);
+                }
+            }
+        }
+        return substitutions;
+    }
+
+    return [];
+}
+
+/**
  * Handle chaining context substitution - format 3
  * @param {ContextParams} contextParams context params to lookup
  */
@@ -250,6 +509,97 @@ function contextSubstitutionFormat1(contextParams, subtable) {
         }
     }
     return null;
+}
+
+/**
+ * Handle context substitution - format 2 (class-based)
+ * @param {ContextParams} contextParams context params to lookup
+ * @param {object} subtable the subtable containing class definitions
+ */
+function contextSubstitutionFormat2(contextParams, subtable) {
+    // Get the current glyph and check if it's in the coverage
+    let glyphIndex = contextParams.current;
+    glyphIndex = Array.isArray(glyphIndex) ? glyphIndex[0] : glyphIndex;
+    const coverageIndex = lookupCoverage(glyphIndex, subtable.coverage);
+    if (coverageIndex === -1) return [];
+
+    // Get the class of the current glyph using the class definition
+    const inputClass = this.font.substitution.getGlyphClass(
+        subtable.classDef,
+        glyphIndex,
+    );
+
+    // Get the class set for this class (may be null for unused classes)
+    const classSet = subtable.classSets[inputClass];
+    if (!classSet) return [];
+
+    // Try each rule in the class set
+    for (let r = 0; r < classSet.length; r++) {
+        const rule = classSet[r];
+
+        // Check input classes (starting from second glyph, first is already matched via coverage)
+        let inputMatch = true;
+        for (let i = 0; i < rule.classes.length; i++) {
+            const inputGlyphIndex = contextParams.lookahead[i];
+            if (inputGlyphIndex === undefined) {
+                inputMatch = false;
+                break;
+            }
+            const inClass = this.font.substitution.getGlyphClass(
+                subtable.classDef,
+                inputGlyphIndex,
+            );
+            if (inClass !== rule.classes[i]) {
+                inputMatch = false;
+                break;
+            }
+        }
+        if (!inputMatch) continue;
+
+        // All context matches! Apply the lookup records
+        let substitutions = [];
+        for (let i = 0; i < rule.lookupRecords.length; i++) {
+            const lookupRecord = rule.lookupRecords[i];
+            const lookupListIndex = lookupRecord.lookupListIndex;
+            const lookupTable = this.getLookupByIndex(lookupListIndex);
+
+            for (let s = 0; s < lookupTable.subtables.length; s++) {
+                let lookupSubtable = lookupTable.subtables[s];
+                let lookup;
+                let substitutionType = this.getSubstitutionType(
+                    lookupTable,
+                    lookupSubtable,
+                );
+
+                if (substitutionType === '71') {
+                    // Extension subtable
+                    substitutionType = this.getSubstitutionType(
+                        lookupSubtable,
+                        lookupSubtable.extension,
+                    );
+                    lookup = this.getLookupMethod(
+                        lookupSubtable,
+                        lookupSubtable.extension,
+                    );
+                    lookupSubtable = lookupSubtable.extension;
+                } else {
+                    lookup = this.getLookupMethod(lookupTable, lookupSubtable);
+                }
+
+                // Get the glyph at the sequence index
+                const seqIndex = lookupRecord.sequenceIndex;
+                const targetGlyph = seqIndex === 0 ? glyphIndex : contextParams.lookahead[seqIndex - 1];
+
+                if (substitutionType === '11' || substitutionType === '12') {
+                    const substitution = lookup(targetGlyph);
+                    if (substitution) substitutions.push(substitution);
+                }
+            }
+        }
+        return substitutions;
+    }
+
+    return [];
 }
 
 /**
@@ -413,6 +763,14 @@ FeatureQuery.prototype.getLookupMethod = function(lookupTable, subtable) {
             return glyphIndex => singleSubstitutionFormat2.apply(
                 this, [glyphIndex, subtable]
             );
+        case '61':
+            return contextParams => chainingSubstitutionFormat1.apply(
+                this, [contextParams, subtable]
+            );
+        case '62':
+            return contextParams => chainingSubstitutionFormat2.apply(
+                this, [contextParams, subtable]
+            );
         case '63':
             return contextParams => chainingSubstitutionFormat3.apply(
                 this, [contextParams, subtable]
@@ -427,6 +785,10 @@ FeatureQuery.prototype.getLookupMethod = function(lookupTable, subtable) {
             );
         case '51':
             return contextParams => contextSubstitutionFormat1.apply(
+                this, [contextParams, subtable]
+            );
+        case '52':
+            return contextParams => contextSubstitutionFormat2.apply(
                 this, [contextParams, subtable]
             );
         case '53':
@@ -518,11 +880,13 @@ FeatureQuery.prototype.lookupFeature = function (query) {
                         }));
                     }
                     break;
+                case '61':
+                case '62':
                 case '63':
                     substitution = lookup(contextParams);
                     if (Array.isArray(substitution) && substitution.length) {
                         substitutions.splice(currentIndex, 1, new SubstitutionAction({
-                            id: 63, tag: query.tag, substitution
+                            id: parseInt(substType), tag: query.tag, substitution
                         }));
                     }
                     break;
@@ -543,6 +907,7 @@ FeatureQuery.prototype.lookupFeature = function (query) {
                     }
                     break;
                 case '51':
+                case '52':
                 case '53':
                     substitution = lookup(contextParams);
                     if (Array.isArray(substitution) && substitution.length) {

--- a/src/features/featureQuery.mjs
+++ b/src/features/featureQuery.mjs
@@ -101,118 +101,148 @@ function lookupCoverageList(coverageList, contextParams) {
 }
 
 /**
+ * Prepare backtrack context by reversing and skipping tashkeel
+ * @param {ContextParams} contextParams context params
+ * @returns {Array} prepared backtrack context
+ */
+function prepareBacktrackContext(contextParams) {
+    const backtrackContext = [].concat(contextParams.backtrack);
+    backtrackContext.reverse();
+    while (backtrackContext.length && isTashkeelArabicChar(backtrackContext[0].char)) {
+        backtrackContext.shift();
+    }
+    return backtrackContext;
+}
+
+/**
+ * Prepare lookahead context by slicing from offset and skipping tashkeel
+ * @param {ContextParams} contextParams context params
+ * @param {number} offset starting offset
+ * @returns {Array} prepared lookahead context
+ */
+function prepareLookaheadContext(contextParams, offset) {
+    const lookaheadContext = contextParams.lookahead.slice(offset);
+    while (lookaheadContext.length && isTashkeelArabicChar(lookaheadContext[0].char)) {
+        lookaheadContext.shift();
+    }
+    return lookaheadContext;
+}
+
+/**
+ * Match a sequence against expected values using a value getter function
+ * @param {Array} context the context to match against
+ * @param {Array} expected expected values to match
+ * @param {Function} getValue function to get comparison value from context item (returns the item by default)
+ * @returns {boolean} true if sequence matches
+ */
+function matchSequence(context, expected, getValue = (item) => item) {
+    if (context.length < expected.length) return false;
+    for (let i = 0; i < expected.length; i++) {
+        if (getValue(context[i]) !== expected[i]) return false;
+    }
+    return true;
+}
+
+/**
+ * Get the current glyph index from context params
+ * @param {ContextParams} contextParams context params
+ */
+function getCurrentGlyphIndex(contextParams) {
+    let glyphIndex = contextParams.current;
+    return Array.isArray(glyphIndex) ? glyphIndex[0] : glyphIndex;
+}
+
+/**
+ * Apply lookup records and return substitutions (shared by all chaining formats)
+ * @param {Array} lookupRecords the lookup records to apply
+ * @param {number} glyphIndex the current glyph index
+ * @param {ContextParams} contextParams context params
+ * @param {object} options optional handlers
+ * @returns {Array} substitutions
+ */
+function applyLookupRecords(lookupRecords, glyphIndex, contextParams, options = {}) {
+    const getTargets = options.getTargets || (
+        (lookupRecord, glyphIndex, contextParams) => {
+            const seqIndex = lookupRecord.sequenceIndex;
+            const targetGlyph = (
+                seqIndex === 0 ? glyphIndex : contextParams.lookahead[seqIndex - 1]
+            );
+            return [targetGlyph];
+        }
+    );
+    const allowedTypes = options.allowedTypes || ['11', '12'];
+    const throwOnUnsupported = options.throwOnUnsupported || false;
+    const substitutions = [];
+    for (let i = 0; i < lookupRecords.length; i++) {
+        const lookupRecord = lookupRecords[i];
+        const lookupListIndex = lookupRecord.lookupListIndex;
+        const lookupTable = this.getLookupByIndex(lookupListIndex);
+
+        for (let s = 0; s < lookupTable.subtables.length; s++) {
+            let lookupSubtable = lookupTable.subtables[s];
+            let lookup;
+            let substitutionType = this.getSubstitutionType(lookupTable, lookupSubtable);
+
+            if (substitutionType === '71') {
+                // Extension subtable
+                substitutionType = this.getSubstitutionType(lookupSubtable, lookupSubtable.extension);
+                lookup = this.getLookupMethod(lookupSubtable, lookupSubtable.extension);
+                lookupSubtable = lookupSubtable.extension;
+            } else {
+                lookup = this.getLookupMethod(lookupTable, lookupSubtable);
+            }
+
+            if (allowedTypes.indexOf(substitutionType) === -1) {
+                if (throwOnUnsupported) {
+                    throw new Error(
+                        `Substitution type ${substitutionType} is not supported in chaining substitution`,
+                    );
+                }
+                continue;
+            }
+
+            const targets = getTargets(lookupRecord, glyphIndex, contextParams);
+            if (!targets || !targets.length) continue;
+
+            for (let t = 0; t < targets.length; t++) {
+                const substitution = lookup(targets[t]);
+                if (substitution) substitutions.push(substitution);
+            }
+        }
+    }
+    return substitutions;
+}
+
+/**
  * Handle chaining context substitution - format 1 (glyph-based)
  * @param {ContextParams} contextParams context params to lookup
  * @param {object} subtable the subtable containing chain rule sets
  */
 function chainingSubstitutionFormat1(contextParams, subtable) {
-    // Get the current glyph and check if it's in the coverage
-    let glyphIndex = contextParams.current;
-    glyphIndex = Array.isArray(glyphIndex) ? glyphIndex[0] : glyphIndex;
+    const glyphIndex = getCurrentGlyphIndex(contextParams);
     const coverageIndex = lookupCoverage(glyphIndex, subtable.coverage);
     if (coverageIndex === -1) return [];
 
-    // Get the chain rule set for this coverage index
     const chainRuleSet = subtable.chainRuleSets[coverageIndex];
     if (!chainRuleSet) return [];
 
-    // Try each rule in the set
+    const backtrackContext = prepareBacktrackContext(contextParams);
+
     for (let r = 0; r < chainRuleSet.length; r++) {
         const rule = chainRuleSet[r];
 
-        // Check backtrack glyphs (in reverse order)
-        let backtrackMatch = true;
-        const backtrackContext = [].concat(contextParams.backtrack);
-        backtrackContext.reverse();
-        // Skip tashkeel (Arabic diacritics)
-        while (backtrackContext.length && isTashkeelArabicChar(backtrackContext[0].char)) {
-            backtrackContext.shift();
-        }
-        if (backtrackContext.length < rule.backtrack.length) {
-            backtrackMatch = false;
-        } else {
-            for (let b = 0; b < rule.backtrack.length; b++) {
-                const backGlyphIndex = backtrackContext[b];
-                if (backGlyphIndex !== rule.backtrack[b]) {
-                    backtrackMatch = false;
-                    break;
-                }
-            }
-        }
-        if (!backtrackMatch) continue;
+        // Check backtrack glyphs
+        if (!matchSequence(backtrackContext, rule.backtrack)) continue;
 
-        // Check input glyphs (starting from second glyph, first is already matched via coverage)
-        let inputMatch = true;
-        for (let i = 0; i < rule.input.length; i++) {
-            const inputGlyphIndex = contextParams.lookahead[i];
-            if (inputGlyphIndex === undefined || inputGlyphIndex !== rule.input[i]) {
-                inputMatch = false;
-                break;
-            }
-        }
-        if (!inputMatch) continue;
+        // Check input glyphs (starting from second glyph)
+        if (!matchSequence(contextParams.lookahead, rule.input)) continue;
 
         // Check lookahead glyphs
-        let lookaheadMatch = true;
-        const lookaheadOffset = rule.input.length;
-        let lookaheadContext = contextParams.lookahead.slice(lookaheadOffset);
-        // Skip tashkeel in lookahead
-        while (lookaheadContext.length && isTashkeelArabicChar(lookaheadContext[0].char)) {
-            lookaheadContext.shift();
-        }
-        if (lookaheadContext.length < rule.lookahead.length) {
-            lookaheadMatch = false;
-        } else {
-            for (let l = 0; l < rule.lookahead.length; l++) {
-                if (lookaheadContext[l] !== rule.lookahead[l]) {
-                    lookaheadMatch = false;
-                    break;
-                }
-            }
-        }
-        if (!lookaheadMatch) continue;
+        const lookaheadContext = prepareLookaheadContext(contextParams, rule.input.length);
+        if (!matchSequence(lookaheadContext, rule.lookahead)) continue;
 
         // All context matches! Apply the lookup records
-        let substitutions = [];
-        for (let i = 0; i < rule.lookupRecords.length; i++) {
-            const lookupRecord = rule.lookupRecords[i];
-            const lookupListIndex = lookupRecord.lookupListIndex;
-            const lookupTable = this.getLookupByIndex(lookupListIndex);
-
-            for (let s = 0; s < lookupTable.subtables.length; s++) {
-                let lookupSubtable = lookupTable.subtables[s];
-                let lookup;
-                let substitutionType = this.getSubstitutionType(
-                    lookupTable,
-                    lookupSubtable,
-                );
-
-                if (substitutionType === '71') {
-                    // Extension subtable
-                    substitutionType = this.getSubstitutionType(
-                        lookupSubtable,
-                        lookupSubtable.extension,
-                    );
-                    lookup = this.getLookupMethod(
-                        lookupSubtable,
-                        lookupSubtable.extension,
-                    );
-                    lookupSubtable = lookupSubtable.extension;
-                } else {
-                    lookup = this.getLookupMethod(lookupTable, lookupSubtable);
-                }
-
-                // Get the glyph at the sequence index
-                const seqIndex = lookupRecord.sequenceIndex;
-                const targetGlyph = seqIndex === 0 ? glyphIndex : contextParams.lookahead[seqIndex - 1];
-
-                if (substitutionType === '11' || substitutionType === '12') {
-                    const substitution = lookup(targetGlyph);
-                    if (substitution) substitutions.push(substitution);
-                }
-            }
-        }
-        return substitutions;
+        return applyLookupRecords.call(this, rule.lookupRecords, glyphIndex, contextParams);
     }
 
     return [];
@@ -224,136 +254,34 @@ function chainingSubstitutionFormat1(contextParams, subtable) {
  * @param {object} subtable the subtable containing class definitions
  */
 function chainingSubstitutionFormat2(contextParams, subtable) {
-    // Get the current glyph and check if it's in the coverage
-    let glyphIndex = contextParams.current;
-    glyphIndex = Array.isArray(glyphIndex) ? glyphIndex[0] : glyphIndex;
+    const glyphIndex = getCurrentGlyphIndex(contextParams);
     const coverageIndex = lookupCoverage(glyphIndex, subtable.coverage);
     if (coverageIndex === -1) return [];
 
-    // Get the class of the current glyph using the input class definition
-    const inputClass = this.font.substitution.getGlyphClass(
-        subtable.inputClassDef,
-        glyphIndex,
-    );
-
-    // Get the chain class set for this class (may be null for unused classes)
+    const inputClass = this.font.substitution.getGlyphClass(subtable.inputClassDef, glyphIndex);
     const chainClassSet = subtable.chainClassSet[inputClass];
     if (!chainClassSet) return [];
 
-    // Try each rule in the class set
+    const backtrackContext = prepareBacktrackContext(contextParams);
+    const getBacktrackClass = (glyph) => this.font.substitution.getGlyphClass(subtable.backtrackClassDef, glyph);
+    const getInputClass = (glyph) => this.font.substitution.getGlyphClass(subtable.inputClassDef, glyph);
+    const getLookaheadClass = (glyph) => this.font.substitution.getGlyphClass(subtable.lookaheadClassDef, glyph);
+
     for (let r = 0; r < chainClassSet.length; r++) {
         const rule = chainClassSet[r];
 
-        // Check backtrack classes (in reverse order)
-        let backtrackMatch = true;
-        const backtrackContext = [].concat(contextParams.backtrack);
-        backtrackContext.reverse();
-        // Skip tashkeel (Arabic diacritics)
-        while (backtrackContext.length && isTashkeelArabicChar(backtrackContext[0].char)) {
-            backtrackContext.shift();
-        }
-        if (backtrackContext.length < rule.backtrack.length) {
-            backtrackMatch = false;
-        } else {
-            for (let b = 0; b < rule.backtrack.length; b++) {
-                const backGlyphIndex = backtrackContext[b];
-                const backClass = this.font.substitution.getGlyphClass(
-                    subtable.backtrackClassDef,
-                    backGlyphIndex,
-                );
-                if (backClass !== rule.backtrack[b]) {
-                    backtrackMatch = false;
-                    break;
-                }
-            }
-        }
-        if (!backtrackMatch) continue;
+        // Check backtrack classes
+        if (!matchSequence(backtrackContext, rule.backtrack, getBacktrackClass)) continue;
 
-        // Check input classes (starting from second glyph, first is already matched via coverage)
-        let inputMatch = true;
-        for (let i = 0; i < rule.input.length; i++) {
-            const inputGlyphIndex = contextParams.lookahead[i];
-            if (inputGlyphIndex === undefined) {
-                inputMatch = false;
-                break;
-            }
-            const inClass = this.font.substitution.getGlyphClass(
-                subtable.inputClassDef,
-                inputGlyphIndex,
-            );
-            if (inClass !== rule.input[i]) {
-                inputMatch = false;
-                break;
-            }
-        }
-        if (!inputMatch) continue;
+        // Check input classes (starting from second glyph)
+        if (!matchSequence(contextParams.lookahead, rule.input, getInputClass)) continue;
 
         // Check lookahead classes
-        let lookaheadMatch = true;
-        const lookaheadOffset = rule.input.length;
-        // Skip tashkeel in lookahead
-        let lookaheadContext = contextParams.lookahead.slice(lookaheadOffset);
-        while (lookaheadContext.length && isTashkeelArabicChar(lookaheadContext[0].char)) {
-            lookaheadContext.shift();
-        }
-        if (lookaheadContext.length < rule.lookahead.length) {
-            lookaheadMatch = false;
-        } else {
-            for (let l = 0; l < rule.lookahead.length; l++) {
-                const lookGlyphIndex = lookaheadContext[l];
-                const lookClass = this.font.substitution.getGlyphClass(
-                    subtable.lookaheadClassDef,
-                    lookGlyphIndex,
-                );
-                if (lookClass !== rule.lookahead[l]) {
-                    lookaheadMatch = false;
-                    break;
-                }
-            }
-        }
-        if (!lookaheadMatch) continue;
+        const lookaheadContext = prepareLookaheadContext(contextParams, rule.input.length);
+        if (!matchSequence(lookaheadContext, rule.lookahead, getLookaheadClass)) continue;
 
         // All context matches! Apply the lookup records
-        let substitutions = [];
-        for (let i = 0; i < rule.lookupRecords.length; i++) {
-            const lookupRecord = rule.lookupRecords[i];
-            const lookupListIndex = lookupRecord.lookupListIndex;
-            const lookupTable = this.getLookupByIndex(lookupListIndex);
-
-            for (let s = 0; s < lookupTable.subtables.length; s++) {
-                let lookupSubtable = lookupTable.subtables[s];
-                let lookup;
-                let substitutionType = this.getSubstitutionType(
-                    lookupTable,
-                    lookupSubtable,
-                );
-
-                if (substitutionType === '71') {
-                    // Extension subtable
-                    substitutionType = this.getSubstitutionType(
-                        lookupSubtable,
-                        lookupSubtable.extension,
-                    );
-                    lookup = this.getLookupMethod(
-                        lookupSubtable,
-                        lookupSubtable.extension,
-                    );
-                    lookupSubtable = lookupSubtable.extension;
-                } else {
-                    lookup = this.getLookupMethod(lookupTable, lookupSubtable);
-                }
-
-                // Get the glyph at the sequence index
-                const seqIndex = lookupRecord.sequenceIndex;
-                const targetGlyph = seqIndex === 0 ? glyphIndex : contextParams.lookahead[seqIndex - 1];
-
-                if (substitutionType === '11' || substitutionType === '12') {
-                    const substitution = lookup(targetGlyph);
-                    if (substitution) substitutions.push(substitution);
-                }
-            }
-        }
-        return substitutions;
+        return applyLookupRecords.call(this, rule.lookupRecords, glyphIndex, contextParams);
     }
 
     return [];
@@ -378,20 +306,13 @@ function chainingSubstitutionFormat3(contextParams, subtable) {
     // LOOKAHEAD LOOKUP //
     const lookaheadOffset = subtable.inputCoverage.length - 1;
     if (contextParams.lookahead.length < subtable.lookaheadCoverage.length) return [];
-    let lookaheadContext = contextParams.lookahead.slice(lookaheadOffset);
-    while (lookaheadContext.length && isTashkeelArabicChar(lookaheadContext[0].char)) {
-        lookaheadContext.shift();
-    }
+    const lookaheadContext = prepareLookaheadContext(contextParams, lookaheadOffset);
     const lookaheadParams = new ContextParams(lookaheadContext, 0);
     let lookaheadLookups = lookupCoverageList(
         subtable.lookaheadCoverage, lookaheadParams
     );
     // BACKTRACK LOOKUP //
-    let backtrackContext = [].concat(contextParams.backtrack);
-    backtrackContext.reverse();
-    while (backtrackContext.length && isTashkeelArabicChar(backtrackContext[0].char)) {
-        backtrackContext.shift();
-    }
+    const backtrackContext = prepareBacktrackContext(contextParams);
     if (backtrackContext.length < subtable.backtrackCoverage.length) return [];
     const backtrackParams = new ContextParams(backtrackContext, 0);
     let backtrackLookups = lookupCoverageList(
@@ -402,41 +323,18 @@ function chainingSubstitutionFormat3(contextParams, subtable) {
         lookaheadLookups.length === subtable.lookaheadCoverage.length &&
         backtrackLookups.length === subtable.backtrackCoverage.length
     );
-    let substitutions = [];
-    if (contextRulesMatch) {
-        for (let i = 0; i < subtable.lookupRecords.length; i++) {
-            const lookupRecord = subtable.lookupRecords[i];
-            const lookupListIndex = lookupRecord.lookupListIndex;
-            const lookupTable = this.getLookupByIndex(lookupListIndex);
-            for (let s = 0; s < lookupTable.subtables.length; s++) {
-                let subtable = lookupTable.subtables[s];
-                let lookup;
-                let substitutionType = this.getSubstitutionType(lookupTable, subtable);
-
-                if (substitutionType === '71') {
-                    // This is an extension subtable, so lookup the target subtable
-                    substitutionType = this.getSubstitutionType(subtable, subtable.extension);
-                    lookup = this.getLookupMethod(subtable, subtable.extension);
-                    subtable = subtable.extension;
-                } else {
-                    lookup = this.getLookupMethod(lookupTable, subtable);
-                }
-
-                if (substitutionType === '12') {
-                    const glyphIndex = contextParams.get(lookupRecord.sequenceIndex);
-                    const substitution = lookup(glyphIndex);
-                    if (substitution) substitutions.push(substitution);
-                } else if (substitutionType === '21') {
-                    const glyphIndex = contextParams.get(lookupRecord.sequenceIndex);
-                    const substitution = lookup(glyphIndex);
-                    if (substitution) substitutions.push(substitution);
-                } else {
-                    throw new Error(`Substitution type ${substitutionType} is not supported in chaining substitution`);
-                }
+    if (!contextRulesMatch) return [];
+    return applyLookupRecords.call(this, subtable.lookupRecords, null, contextParams, {
+        allowedTypes: ['12', '21'],
+        throwOnUnsupported: true,
+        getTargets: () => {
+            let targets = [];
+            for (let n = 0; n < inputLookups.length; n++) {
+                targets.push(contextParams.get(n));
             }
-        }
-    }
-    return substitutions;
+            return targets;
+        },
+    });
 }
 
 /**

--- a/src/features/featureQuery.mjs
+++ b/src/features/featureQuery.mjs
@@ -171,7 +171,6 @@ function applyLookupRecords(lookupRecords, glyphIndex, contextParams, options = 
         }
     );
     const allowedTypes = options.allowedTypes || ['11', '12'];
-    const throwOnUnsupported = options.throwOnUnsupported || false;
     const substitutions = [];
     for (let i = 0; i < lookupRecords.length; i++) {
         const lookupRecord = lookupRecords[i];
@@ -193,12 +192,9 @@ function applyLookupRecords(lookupRecords, glyphIndex, contextParams, options = 
             }
 
             if (allowedTypes.indexOf(substitutionType) === -1) {
-                if (throwOnUnsupported) {
-                    throw new Error(
-                        `Substitution type ${substitutionType} is not supported in chaining substitution`,
-                    );
-                }
-                continue;
+                throw new Error(
+                    `Substitution type ${substitutionType} is not supported in chaining substitution`,
+                );
             }
 
             const targets = getTargets(lookupRecord, glyphIndex, contextParams);
@@ -326,7 +322,6 @@ function chainingSubstitutionFormat3(contextParams, subtable) {
     if (!contextRulesMatch) return [];
     return applyLookupRecords.call(this, subtable.lookupRecords, null, contextParams, {
         allowedTypes: ['12', '21'],
-        throwOnUnsupported: true,
         getTargets: () => {
             let targets = [];
             for (let n = 0; n < inputLookups.length; n++) {

--- a/src/variationprocessor.mjs
+++ b/src/variationprocessor.mjs
@@ -402,7 +402,7 @@ export class VariationProcessor {
             for (let c = 0; c < glyph.components.length; c++) {
                 const component = glyph.components[c];
                 const componentGlyph = this.font.glyphs.get(component.glyphIndex);
-                componentGlyph.getPath();
+                // Note that .points is a getter that will lazy-load the path.
                 const pointCount = componentGlyph.points.length;
                 const deltaAdvance = this.font.tables.hvar ?
                     this.getVariableAdjustment(componentGlyph.index, 'hvar', 'advanceWidth', coords) :

--- a/src/variationprocessor.mjs
+++ b/src/variationprocessor.mjs
@@ -394,12 +394,47 @@ export class VariationProcessor {
             }
         }
 
+        // Composite glyphs need component positions adjusted by per-component HVAR deltas.
+        // TODO: add VVAR support for vertical advances when available.
+        if (glyph.isComposite && glyph.components && glyph.components.length && transformedGlyph.points) {
+            const componentInfos = [];
+            let pointOffset = 0;
+            for (let c = 0; c < glyph.components.length; c++) {
+                const component = glyph.components[c];
+                const componentGlyph = this.font.glyphs.get(component.glyphIndex);
+                componentGlyph.getPath();
+                const pointCount = componentGlyph.points.length;
+                const deltaAdvance = this.font.tables.hvar ?
+                    this.getVariableAdjustment(componentGlyph.index, 'hvar', 'advanceWidth', coords) :
+                    0;
+                componentInfos.push({
+                    pointOffset,
+                    pointCount,
+                    deltaAdvanceWidth: deltaAdvance
+                });
+                pointOffset += pointCount;
+            }
+            let cumulativeShift = 0;
+            const shiftedPoints = transformedGlyph.points.map(copyPoint);
+            for (let i = 0; i < componentInfos.length; i++) {
+                const info = componentInfos[i];
+                // Each component shifts by the sum of prior component width deltas.
+                for (let p = info.pointOffset; p < info.pointOffset + info.pointCount; p++) {
+                    shiftedPoints[p].x = Math.round(shiftedPoints[p].x + cumulativeShift);
+                }
+                cumulativeShift += info.deltaAdvanceWidth;
+            }
+            transformedGlyph = new Glyph(Object.assign({}, transformedGlyph, {points: shiftedPoints, path: getPath(shiftedPoints)}));
+        }
+
         if(this.font.tables.hvar) {
             glyph._advanceWidth = typeof glyph._advanceWidth !== 'undefined' ? glyph._advanceWidth: glyph.advanceWidth;
-            glyph.advanceWidth = transformedGlyph.advanceWidth = Math.round(glyph._advanceWidth + this.getVariableAdjustment(transformedGlyph.index, 'hvar', 'advanceWidth', coords));
+            const advanceDelta = this.getVariableAdjustment(transformedGlyph.index, 'hvar', 'advanceWidth', coords);
+            glyph.advanceWidth = transformedGlyph.advanceWidth = Math.round(glyph._advanceWidth + advanceDelta);
             
             glyph._leftSideBearing = typeof glyph._leftSideBearing !== 'undefined' ? glyph._leftSideBearing: glyph.leftSideBearing;
-            glyph.leftSideBearing = transformedGlyph.leftSideBearing = Math.round(glyph._leftSideBearing + this.getVariableAdjustment(transformedGlyph.index, 'hvar', 'lsb', coords));
+            const lsbDelta = this.getVariableAdjustment(transformedGlyph.index, 'hvar', 'lsb', coords);
+            glyph.leftSideBearing = transformedGlyph.leftSideBearing = Math.round(glyph._leftSideBearing + lsbDelta);
         }
 
         return transformedGlyph;

--- a/test/applySubstitution.spec.mjs
+++ b/test/applySubstitution.spec.mjs
@@ -1,0 +1,27 @@
+import assert from 'assert';
+import applySubstitution from '../src/features/applySubstitution.mjs';
+import { SubstitutionAction } from '../src/features/featureQuery.mjs';
+import { Token } from '../src/tokenizer.mjs';
+
+describe('applySubstitution.mjs', function() {
+    it('should apply chaining substitutions for ids 61, 62, and 52', function() {
+        const tokens = [new Token('a'), new Token('b'), new Token('c')];
+        const substitutions = [200, [201], []];
+        const tag = 'test';
+        const actionIds = [61, 62, 52];
+
+        for (let i = 0; i < actionIds.length; i++) {
+            const action = new SubstitutionAction({
+                id: actionIds[i],
+                tag,
+                substitution: substitutions
+            });
+
+            applySubstitution(action, tokens, 0);
+
+            assert.equal(tokens[0].getState(tag), 200);
+            assert.equal(tokens[1].getState(tag), 201);
+            assert.equal(tokens[2].getState('deleted'), true);
+        }
+    });
+});

--- a/test/featureQuery.spec.mjs
+++ b/test/featureQuery.spec.mjs
@@ -6,6 +6,7 @@ import { readFileSync } from 'fs';
 
 const loadSync = (url, opt) => parse(readFileSync(url), opt);
 
+// Extracted from layout.mjs for testing
 const getGlyphClass = function(classDefTable, glyphIndex) {
     switch (classDefTable.format) {
         case 1: {
@@ -192,7 +193,7 @@ describe('featureQuery.mjs', function() {
             const lookupSubtables = query.sub5.getLookupSubtables(featureLookups[1]);
             const substitutionType = query.sub5.getSubstitutionType(featureLookups[1], lookupSubtables[0]);
             assert.equal(substitutionType, 53);
-            const lookup = query.sub5.getLookupMethod(featureLookups[0], lookupSubtables[0]);
+            const lookup = query.sub5.getLookupMethod(featureLookups[1], lookupSubtables[0]);
             let contextParams = new ContextParams([2, 3], 0);
             const substitutions = lookup(contextParams);
             assert.deepEqual(substitutions, [54, 54]);
@@ -209,21 +210,48 @@ describe('featureQuery.mjs', function() {
         });
         it('should route context substitution format 2 (52) correctly', function () {
             // This test verifies that case '52' is registered in getLookupMethod switch
-            // Without this case, getLookupMethod would throw an error for format 2 context substitutions
             const featureQuery = query.arabic;
-            
-            // Mock a lookup table and subtable with substitution type 52
             const mockLookupTable = { lookupType: 5 }; // Context substitution type 5
             const mockSubtable = { substFormat: 2 }; // Format 2 (class-based)
-            
-            // This should not throw an error if case '52' is registered
-            try {
-                const substitutionType = featureQuery.getSubstitutionType(mockLookupTable, mockSubtable);
-                // Type 5 format 2 should be '52'
-                assert.equal(substitutionType, '52');
-            } catch (e) {
-                assert.fail('getLookupMethod should handle case "52" for context substitution format 2');
-            }
+
+            const substitutionType = featureQuery.getSubstitutionType(mockLookupTable, mockSubtable);
+            assert.equal(substitutionType, '52');
+
+            const lookup = featureQuery.getLookupMethod(mockLookupTable, mockSubtable);
+            assert.ok(typeof lookup === 'function', 'getLookupMethod should return a function for case 52');
+        });
+        it('should apply context substitution format 2 (52) using lookup records', function () {
+            const singleSubtable = {
+                substFormat: 1,
+                coverage: { format: 1, glyphs: [10] },
+                deltaGlyphId: 5
+            };
+            const singleLookupTable = { lookupType: 1, subtables: [singleSubtable] };
+            const contextSubtable = {
+                substFormat: 2,
+                coverage: { format: 1, glyphs: [10] },
+                classDef: {
+                    format: 2,
+                    ranges: [
+                        { start: 10, end: 10, classId: 1 },
+                        { start: 20, end: 20, classId: 2 }
+                    ]
+                },
+                classSets: [
+                    null,
+                    [{ classes: [2], lookupRecords: [{ sequenceIndex: 0, lookupListIndex: 0 }] }]
+                ]
+            };
+            const contextLookupTable = { lookupType: 5, subtables: [contextSubtable] };
+            const mockFont = {
+                tables: { gsub: { lookups: [singleLookupTable] } },
+                substitution: { getGlyphClass }
+            };
+            const featureQuery = new FeatureQuery(mockFont);
+            const lookup = featureQuery.getLookupMethod(contextLookupTable, contextSubtable);
+            const contextParams = new ContextParams([10, 20], 0);
+            const substitutions = lookup(contextParams);
+            assert.deepEqual(substitutions, [15]);
         });
         it('should route chaining context substitution format 2 (62) correctly', function () {
             // This test verifies that case '62' is registered in getLookupMethod switch

--- a/test/featureQuery.spec.mjs
+++ b/test/featureQuery.spec.mjs
@@ -183,5 +183,45 @@ describe('featureQuery.mjs', function() {
             const substitution = lookup(271);
             assert.deepEqual(substitution, [273, 1087]);
         });
+        it('should route context substitution format 2 (52) correctly', function () {
+            // This test verifies that case '52' is registered in getLookupMethod switch
+            // Without this case, getLookupMethod would throw an error for format 2 context substitutions
+            const featureQuery = query.arabic;
+            
+            // Mock a lookup table and subtable with substitution type 52
+            const mockLookupTable = { lookupType: 5 }; // Context substitution type 5
+            const mockSubtable = { substFormat: 2 }; // Format 2 (class-based)
+            
+            // This should not throw an error if case '52' is registered
+            try {
+                const substitutionType = featureQuery.getSubstitutionType(mockLookupTable, mockSubtable);
+                // Type 5 format 2 should be '52'
+                assert.equal(substitutionType, '52');
+            } catch (e) {
+                assert.fail('getLookupMethod should handle case "52" for context substitution format 2');
+            }
+        });
+        it('should route chaining context substitution format 2 (62) correctly', function () {
+            // This test verifies that case '62' is registered in getLookupMethod switch
+            // Without this case, getLookupMethod would throw an error for format 2 chaining context substitutions
+            const featureQuery = query.arabic;
+            
+            // Mock a lookup table and subtable with substitution type 62
+            const mockLookupTable = { lookupType: 6 }; // Chaining context substitution type 6
+            const mockSubtable = { substFormat: 2 }; // Format 2 (class-based)
+            
+            // This should not throw an error if case '62' is registered
+            try {
+                const substitutionType = featureQuery.getSubstitutionType(mockLookupTable, mockSubtable);
+                // Type 6 format 2 should be '62'
+                assert.equal(substitutionType, '62');
+                
+                // Verify getLookupMethod recognizes the type without throwing
+                const lookup = featureQuery.getLookupMethod(mockLookupTable, mockSubtable);
+                assert.ok(typeof lookup === 'function', 'getLookupMethod should return a function for case 62');
+            } catch (e) {
+                assert.fail(`getLookupMethod should handle case "62" for chaining context substitution format 2: ${e.message}`);
+            }
+        });
     });
 });

--- a/test/featureQuery.spec.mjs
+++ b/test/featureQuery.spec.mjs
@@ -3,7 +3,31 @@ import { parse } from '../src/opentype.mjs';
 import FeatureQuery from '../src/features/featureQuery.mjs';
 import { ContextParams } from '../src/tokenizer.mjs';
 import { readFileSync } from 'fs';
+
 const loadSync = (url, opt) => parse(readFileSync(url), opt);
+
+const getGlyphClass = function(classDefTable, glyphIndex) {
+    switch (classDefTable.format) {
+        case 1: {
+            if (classDefTable.startGlyph <= glyphIndex &&
+                glyphIndex < classDefTable.startGlyph + classDefTable.classes.length) {
+                return classDefTable.classes[glyphIndex - classDefTable.startGlyph];
+            }
+            return 0;
+        }
+        case 2: {
+            const ranges = classDefTable.ranges;
+            for (let i = 0; i < ranges.length; i++) {
+                const range = ranges[i];
+                if (glyphIndex >= range.start && glyphIndex <= range.end) {
+                    return range.classId;
+                }
+            }
+            return 0;
+        }
+    }
+    return 0;
+};
 
 describe('featureQuery.mjs', function() {
     let arabicFont;
@@ -222,6 +246,80 @@ describe('featureQuery.mjs', function() {
             } catch (e) {
                 assert.fail(`getLookupMethod should handle case "62" for chaining context substitution format 2: ${e.message}`);
             }
+        });
+        it('should apply chaining context substitution format 1 (61) using lookup records', function () {
+            const singleSubtable = {
+                substFormat: 1,
+                coverage: { format: 1, glyphs: [10] },
+                deltaGlyphId: 1
+            };
+            const singleLookupTable = {
+                lookupType: 1,
+                subtables: [singleSubtable]
+            };
+            const chainingSubtable = {
+                substFormat: 1,
+                coverage: { format: 1, glyphs: [10] },
+                chainRuleSets: [[{
+                    backtrack: [1],
+                    input: [20, 21],
+                    lookahead: [30],
+                    lookupRecords: [{ sequenceIndex: 0, lookupListIndex: 0 }]
+                }]]
+            };
+            const chainingLookupTable = { lookupType: 6, subtables: [chainingSubtable] };
+            const mockFont = {
+                tables: { gsub: { lookups: [singleLookupTable] } },
+                substitution: { getGlyphClass }
+            };
+            const featureQuery = new FeatureQuery(mockFont);
+            const lookup = featureQuery.getLookupMethod(chainingLookupTable, chainingSubtable);
+            const contextParams = new ContextParams([1, 10, 20, 21, 30], 1);
+            const substitutions = lookup(contextParams);
+            assert.deepEqual(substitutions, [11]);
+        });
+        it('should apply chaining context substitution format 2 (62) using lookup records', function () {
+            const singleSubtable = {
+                substFormat: 1,
+                coverage: { format: 1, glyphs: [10] },
+                deltaGlyphId: 5
+            };
+            const singleLookupTable = {
+                lookupType: 1,
+                subtables: [singleSubtable]
+            };
+            const chainingSubtable = {
+                substFormat: 2,
+                coverage: { format: 1, glyphs: [10] },
+                backtrackClassDef: { format: 2, ranges: [{ start: 1, end: 1, classId: 2 }] },
+                inputClassDef: {
+                    format: 2,
+                    ranges: [
+                        { start: 10, end: 10, classId: 1 },
+                        { start: 20, end: 20, classId: 3 }
+                    ]
+                },
+                lookaheadClassDef: { format: 2, ranges: [{ start: 30, end: 30, classId: 4 }] },
+                chainClassSet: [
+                    null,
+                    [{
+                        backtrack: [2],
+                        input: [3],
+                        lookahead: [4],
+                        lookupRecords: [{ sequenceIndex: 0, lookupListIndex: 0 }]
+                    }]
+                ]
+            };
+            const chainingLookupTable = { lookupType: 6, subtables: [chainingSubtable] };
+            const mockFont = {
+                tables: { gsub: { lookups: [singleLookupTable] } },
+                substitution: { getGlyphClass }
+            };
+            const featureQuery = new FeatureQuery(mockFont);
+            const lookup = featureQuery.getLookupMethod(chainingLookupTable, chainingSubtable);
+            const contextParams = new ContextParams([1, 10, 20, 30], 1);
+            const substitutions = lookup(contextParams);
+            assert.deepEqual(substitutions, [15]);
         });
     });
 });

--- a/test/variation.spec.mjs
+++ b/test/variation.spec.mjs
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { parse } from '../src/opentype.mjs';
+import { VariationProcessor } from '../src/variationprocessor.mjs';
 import { readFileSync } from 'fs';
 import exp from 'constants';
 const loadSync = (url, opt) => parse(readFileSync(url), opt);
@@ -131,6 +132,67 @@ describe('variation.mjs', function() {
     });
     
     describe('hvar', function() {
+        it('shifts composite component points by cumulative advance deltas', function() {
+            const component1 = {
+                index: 1,
+                advanceWidth: 100,
+                points: [{x: 10, y: 0, onCurve: true, lastPointOfContour: true}],
+                getPath: () => ({commands: []})
+            };
+            const component2 = {
+                index: 2,
+                advanceWidth: 100,
+                points: [{x: 110, y: 0, onCurve: true, lastPointOfContour: true}],
+                getPath: () => ({commands: []})
+            };
+            const component3 = {
+                index: 3,
+                advanceWidth: 100,
+                points: [{x: 210, y: 0, onCurve: true, lastPointOfContour: true}],
+                getPath: () => ({commands: []})
+            };
+            const composite = {
+                index: 10,
+                isComposite: true,
+                components: [
+                    {glyphIndex: 1},
+                    {glyphIndex: 2},
+                    {glyphIndex: 3}
+                ],
+                points: [
+                    component1.points[0],
+                    component2.points[0],
+                    component3.points[0]
+                ],
+                advanceWidth: 300,
+                leftSideBearing: 0
+            };
+
+            const glyphMap = {
+                1: component1,
+                2: component2,
+                3: component3,
+                10: composite
+            };
+
+            const font = {
+                glyphs: { get: (id) => glyphMap[id] },
+                tables: { hvar: {} },
+                variation: { get: () => ({}) },
+                defaultRenderOptions: { variation: {} }
+            };
+
+            const processor = new VariationProcessor(font);
+            // Fake HVAR per-component advance deltas to validate cumulative shifts.
+            processor.getVariableAdjustment = (gid, tableName, parameter) => {
+                if (tableName !== 'hvar' || parameter !== 'advanceWidth') return 0;
+                return {1: -10, 2: -20, 3: -30}[gid] || 0;
+            };
+
+            const transformed = processor.getTransform(composite, {});
+            assert.deepEqual(transformed.points.map((pt) => pt.x), [10, 100, 180]);
+        });
+
         it('transforms advanceWidth', function() {
             let font = fonts.hvar;
             let glyphPos = [];


### PR DESCRIPTION
This PR makes the Google Roboto font work with opentype.js, and presumably many others.

Note that AI assistance was used in creating this PR.

## Description
* This PR adds support for gsub tables 61 (chaining substitution format 1), 62 (chaining substitution format 2), and 52 (context substitution - format 2). 
* The PR also improves rendering of variable-width composite glyphs used for ligatures, like "ffi" in "affinity" in some fonts. Previously, as the font width was narrowed, the intra-ligature advances were not proportionally scaled causing incorrect inter-glyph spacing and overlaps with subsequent glyphs. This fix is does not correct all issues with composite glyphs however.

## Motivation and Context
The chaining formats are used by newer Google variable fonts, like Roboto, and these changes allow those fonts to work correctly with opentype.js. Also, words like "affinity" were not getting rendered correctly in variable width fonts.

## How Has This Been Tested?
Primary testing has been with Google fonts such as Roboto and Noto Sans using the opentype.js font test pages.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **Contribute** README section.
