### PR TITLE
Fix small bugs, typos, and inconsistencies

### DIFF
--- a/src/font.mjs
+++ b/src/font.mjs
@@ -77,11 +77,11 @@ function Font(options) {
 
     if (!options.empty) {
         // Check that we've provided the minimum set of names.
-        if (!options.familyName) throw 'When creating a new Font object, familyName is required.';
-        if (!options.styleName) throw 'When creating a new Font object, styleName is required.';
-        if (!options.unitsPerEm) throw 'When creating a new Font object, unitsPerEm is required.';
-        if (!options.ascender) throw 'When creating a new Font object, ascender is required.';
-        if (options.descender > 0) throw 'When creating a new Font object, negative descender value is required.';
+        if (!options.familyName) throw new Error('When creating a new Font object, familyName is required.');
+        if (!options.styleName) throw new Error('When creating a new Font object, styleName is required.');
+        if (!options.unitsPerEm) throw new Error('When creating a new Font object, unitsPerEm is required.');
+        if (!options.ascender) throw new Error('When creating a new Font object, ascender is required.');
+        if (options.descender > 0) throw new Error('When creating a new Font object, negative descender value is required.');
 
         // OS X will complain if the names are empty, so we put a single space everywhere by default.
         this.names = {};

--- a/src/font.mjs
+++ b/src/font.mjs
@@ -367,7 +367,7 @@ Font.prototype.defaultRenderOptions = {
 
 /**
  * Helper function that invokes the given callback for each glyph in the given text.
- * The callback gets `(glyph, x, y, fontSize, options)`.* @param  {string} text
+ * The callback gets `(glyph, x, y, fontSize, options)`.
  * @param {string} text - The text to apply.
  * @param  {number} [x=0] - Horizontal position of the beginning of the text.
  * @param  {number} [y=0] - Vertical position of the *baseline* of the text.

--- a/src/font.mjs
+++ b/src/font.mjs
@@ -107,7 +107,7 @@ function Font(options) {
             if (this.weightClass >= 600) {
                 selection |= this.fsSelectionValues.BOLD;
             }
-            if (selection == 0) {
+            if (selection === 0) {
                 selection = this.fsSelectionValues.REGULAR;
             }
         }

--- a/src/glyph.mjs
+++ b/src/glyph.mjs
@@ -357,7 +357,7 @@ Glyph.prototype.getMetrics = function() {
  * @param  {opentype.Font} font - if hinting is to be used, or CPAL/COLR / variation needs to be rendered, the font
  */
 Glyph.prototype.draw = function(ctx, x, y, fontSize, options, font) {
-    options = Object.assign({}, font.defaultRenderOptions, options);
+    options = Object.assign({}, font && font.defaultRenderOptions, options);
     const path = this.getPath(x, y, fontSize, options, font);
     path.draw(ctx);
 };

--- a/src/glyph.mjs
+++ b/src/glyph.mjs
@@ -489,8 +489,8 @@ Glyph.prototype.toPathData = function(options, font) {
     }
 
     let usePath = useGlyph.points && options.pointsTransform ? options.pointsTransform(useGlyph.points) : useGlyph.path;
-    if(options.pathTramsform) {
-        usePath = options.pathTramsform(usePath);
+    if(options.pathTransform) {
+        usePath = options.pathTransform(usePath);
     }
 
     return usePath.toPathData(options);

--- a/src/glyph.mjs
+++ b/src/glyph.mjs
@@ -247,7 +247,7 @@ Glyph.prototype.getPath = function(x, y, fontSize, options, font) {
  */
 Glyph.prototype.getLayers = function(font) {
     if(!font) {
-        throw Error('The font object is required to read the colr/cpal tables in order to get the layers.');
+        throw new Error('The font object is required to read the colr/cpal tables in order to get the layers.');
     }
     return font.layers.get(this.index);
 };
@@ -258,7 +258,7 @@ Glyph.prototype.getLayers = function(font) {
  */
 Glyph.prototype.getSvgImage = function(font) {
     if(!font) {
-        throw Error('The font object is required to read the svg table in order to get the image.');
+        throw new Error('The font object is required to read the svg table in order to get the image.');
     }
     return font.svgImages.get(this.index);
 };

--- a/src/opentype.mjs
+++ b/src/opentype.mjs
@@ -170,7 +170,7 @@ function parseBuffer(buffer, opt={}) {
         numTables = parse.getUShort(data, 12);
         tableEntries = parseWOFFTableEntries(data, numTables);
     } else if (signature === 'wOF2') {
-        var issue = 'https://github.com/opentypejs/opentype.js/issues/183#issuecomment-1147228025';
+        const issue = 'https://github.com/opentypejs/opentype.js/issues/183#issuecomment-1147228025';
         throw new Error('WOFF2 require an external decompressor library, see examples at: ' + issue);
     } else {
         throw new Error('Unsupported OpenType signature ' + signature);

--- a/src/parse.mjs
+++ b/src/parse.mjs
@@ -773,7 +773,7 @@ Parser.prototype.parseDeltaSetIndexMap = function() {
         } else if (entrySize === 3) {
             entry = this.parseUInt24();
         } else if (entrySize === 4) {
-            entry = this.getULong();
+            entry = this.parseULong();
         } else {
             throw new Error(`Invalid entry size of ${entrySize}`);
         }

--- a/src/path.mjs
+++ b/src/path.mjs
@@ -687,7 +687,7 @@ Path.prototype.toSVG = function(options, pathData) {
 /**
  * Convert the path to a DOM element.
  * @param  {object|number} [options={decimalPlaces:2, optimize:true}] - Options object (or amount of decimal places for floating-point values for backwards compatibility)
- * @param  {string} - will be calculated automatically, but can be provided from Glyph's wrapper functionions object (or amount of decimal places for floating-point values for backwards compatibility)
+ * @param  {string} [pathData] - will be calculated automatically, but can be provided from Glyph's wrapper functions
  * @return {SVGPathElement}
  */
 Path.prototype.toDOMElement = function(options, pathData) {

--- a/src/path.mjs
+++ b/src/path.mjs
@@ -56,7 +56,7 @@ function optimizeCommands(commands) {
         if (cmd.type === 'M') {
             startX = cmd.x;
             startY = cmd.y;
-        } else if (cmd.type === 'L' && (!nextCommand || nextCommand.command === 'Z')) {
+        } else if (cmd.type === 'L' && (!nextCommand || nextCommand.type === 'Z')) {
             if(!(Math.abs(cmd.x - startX) > 1 || Math.abs(cmd.y - startY) > 1)) {
                 subpath.pop();
             }

--- a/src/path.mjs
+++ b/src/path.mjs
@@ -701,10 +701,9 @@ Path.prototype.toDOMElement = function(options, pathData) {
     if (!pathData) {
         pathData = this.toPathData(options);
     }
-    const temporaryPath = pathData;
     const newPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
-    newPath.setAttribute('d', temporaryPath);
+    newPath.setAttribute('d', pathData);
 
     if (this.fill !== undefined && this.fill !== 'black') {
         if (this.fill === null) {

--- a/src/tables/glyf.mjs
+++ b/src/tables/glyf.mjs
@@ -107,7 +107,7 @@ function parseGlyph(glyph, data, start) {
         } else {
             glyph.points = [];
         }
-    } else if (glyph.numberOfContours === 0) {
+    } else if (glyph._numberOfContours === 0) {
         glyph.points = [];
     } else {
         glyph.isComposite = true;

--- a/test/font.spec.mjs
+++ b/test/font.spec.mjs
@@ -35,6 +35,13 @@ describe('font.mjs', function() {
     });
 
     describe('Font constructor', function() {
+        it('should throw Error objects (not strings) for missing required options', function() {
+            assert.throws(
+                () => new Font({ styleName: 'Medium', unitsPerEm: 1000, ascender: 800, descender: -200 }),
+                (err) => err instanceof Error
+            );
+        });
+
         it('accept 0 as descender value', function() {
             assert.equal(font.descender, 0);
         });

--- a/test/glyph.spec.mjs
+++ b/test/glyph.spec.mjs
@@ -146,6 +146,21 @@ describe('glyph.mjs', function() {
         });
     });
 
+    describe('toPathData options', function() {
+        it('should invoke pathTransform callback', function() {
+            const font = loadSync('./test/fonts/FiraSansMedium.woff');
+            const glyph = font.charToGlyph('A');
+            let called = false;
+            glyph.toPathData({
+                pathTransform: function(path) {
+                    called = true;
+                    return path;
+                }
+            }, font);
+            assert.equal(called, true);
+        });
+    });
+
     describe('component transformation', function() {
         // @TODO test components more thoroughly,
         // maybe move to a separate glyf test file

--- a/test/glyph.spec.mjs
+++ b/test/glyph.spec.mjs
@@ -154,7 +154,7 @@ describe('glyph.mjs', function() {
 
         it('handles 2x2 transform correctly',function() {
             const glyph = changaVarFont.charToGlyph('+');
-            assert.deepEqual(glyph.toPathData(), 'M91 284L440 284L440 342L91 342ZM236 487L236 138L294 138L294 487Z');
+            assert.deepEqual(glyph.toPathData(), 'M91 342L91 284L440 284L440 342ZM294 487L236 487L236 138L294 138Z');
         });
     });
 

--- a/test/path.spec.mjs
+++ b/test/path.spec.mjs
@@ -88,8 +88,20 @@ describe('path.mjs', function() {
         assert.equal(testPath2.toPathData({optimize: false, flipY: false}), unoptimizedResult);
     });
     
+    it('should remove redundant lineTo before close when coordinates match start', function() {
+        const path = new Path();
+        path.moveTo(100, 200);
+        path.lineTo(300, 200);
+        path.lineTo(300, 400);
+        path.lineTo(100, 200); // redundant: same as start
+        path.close();
+        const result = path.toPathData({optimize: true, flipY: false});
+        // The redundant L100 200 before Z should be removed
+        assert.equal(result, 'M100 200L300 200L300 400Z');
+    });
+
     it('should optimize SVG paths if path closing point matches starting point', function() {
-        const optimizedResult = 'M0 250L50 250L100 250L150 250L200 250L200 50L0 50ZM250 250L300 250L350 250L400 250L450 250L450 50L250 50Z';
+        const optimizedResult = 'M0 50L0 250L50 250L100 250L150 250L200 250L200 50ZM250 50L250 250L300 250L350 250L400 250L450 250L450 50Z';
         assert.equal(testPath2.toPathData({flipY: false}), optimizedResult);
         assert.equal(testPath2.toPathData({optimize: true, flipY: false}), optimizedResult);
     });


### PR DESCRIPTION
## Summary
- **Fix actual bugs**: `.command` → `.type` in path optimization (dead code), `pathTramsform` typo (callback silently ignored), `getULong` → `parseULong` (would crash), `numberOfContours` → `_numberOfContours` (wrong property access), null crash in `Glyph.draw`
- **Fix throw hygiene**: throw `Error` objects instead of strings in Font constructor, add `new` keyword to `throw Error()` calls
- **Code quality**: `==` → `===`, `var` → `const`, remove unnecessary variable, fix two malformed JSDoc blocks

Each fix is in its own commit. 3 fixes include red/green TDD tests (321 total, up from 318).

## Test plan
- [x] All 321 tests pass
- [x] ESLint passes
- [x] Each commit individually tested before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)