### PR TITLE
Fix GitHub Pages deployment by upgrading actions

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -14,18 +14,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
     - run: npm install
     - run: npm run build
     - run: npm run dist
     - run: mv dist docs
-    - uses: actions/configure-pages@v3
-    - uses: actions/upload-pages-artifact@v1
+    - uses: actions/configure-pages@v5
+    - uses: actions/upload-pages-artifact@v3
       with:
         path: docs
-    - run: find docs
-    - uses: actions/deploy-pages@v1
+    - uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
## Summary
- Upgraded all GitHub Actions in the pages workflow to their latest major versions to fix the deployment failure caused by deprecated `actions/upload-artifact@v3`
- Bumped Node.js from 18 to 22
- Removed debug `find docs` step

## Test plan
- [ ] Verify the GitHub Pages deployment workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)