### PR TITLE
fix(sfnt): mask bytes to 8-bit in computeCheckSum for non-ASCII data

### DIFF
--- a/src/tables/cmap.mjs
+++ b/src/tables/cmap.mjs
@@ -269,6 +269,12 @@ function mergeSegments(segments) {
     return merged;
 }
 
+// The Format 4 length field is a USHORT, capping the subtable at 65535 bytes.
+// Each segment contributes 8 bytes (one entry in each of the four parallel arrays),
+// plus the 14-byte header and the 2-byte reservedPad, leaving room for at most
+// floor((65535 - 16) / 8) = 8189 segments before overflow.
+const CMAP4_MAX_SEGMENTS = Math.floor((0xFFFF - 16) / 8);
+
 // Make cmap table, format 4 by default, 12 if needed only
 function makeCmapTable(glyphs) {
     // Plan 0 is the base Unicode Plan but emojis, for example are on another plan, and needs cmap 12 format (with 32bit)
@@ -282,6 +288,29 @@ function makeCmapTable(glyphs) {
             isPlan0Only = false;
             break;
         }
+    }
+
+    // Build and merge segments up front so we can measure the true segment count
+    // before committing to a table layout.
+    const allSegments = [];
+    for (i = 0; i < glyphs.length; i += 1) {
+        const glyph = glyphs.get(i);
+        for (let j = 0; j < glyph.unicodes.length; j += 1) {
+            addSegment({ segments: allSegments }, glyph.unicodes[j], i);
+        }
+    }
+    allSegments.sort(function(a, b) { return a.start - b.start; });
+    const mergedSegments = mergeSegments(allSegments);
+
+    // Count BMP segments (those that fit in Format 4).  If after merging the
+    // count still exceeds what a USHORT length field can encode, Format 4 cannot
+    // represent the full mapping without silent truncation.  In that case we fall
+    // back to emitting Format 12 for all glyphs, keeping a minimal Format 4
+    // subtable (terminator only) for parsers that require its presence.
+    const bmpSegmentCount = mergedSegments.filter(s => s.start <= 0xFFFF).length;
+    const cmap4Overflows = bmpSegmentCount > CMAP4_MAX_SEGMENTS;
+    if (cmap4Overflows) {
+        isPlan0Only = false;
     }
 
     let cmapTable = [
@@ -315,18 +344,7 @@ function makeCmapTable(glyphs) {
 
     const t = new table.Table('cmap', cmapTable);
 
-    t.segments = [];
-    for (i = 0; i < glyphs.length; i += 1) {
-        const glyph = glyphs.get(i);
-        for (let j = 0; j < glyph.unicodes.length; j += 1) {
-            addSegment(t, glyph.unicodes[j], i);
-        }
-    }
-    t.segments.sort(function (a, b) {
-        return a.start - b.start;
-    });
-
-    t.segments = mergeSegments(t.segments);
+    t.segments = mergedSegments;
 
     addTerminatorSegment(t);
 
@@ -347,8 +365,12 @@ function makeCmapTable(glyphs) {
     for (i = 0; i < segCount; i += 1) {
         const segment = t.segments[i];
 
-        // CMAP 4
-        if (segment.end <= 65535 && segment.start <= 65535) {
+        // CMAP 4: when the table would overflow, emit only the terminator segment
+        // so that Format 4 remains structurally valid.  All actual mappings are
+        // carried by the Format 12 subtable in that case.
+        const includeInCmap4 = segment.end <= 65535 && segment.start <= 65535 && !cmap4Overflows ||
+            (cmap4Overflows && segment.end === 0xFFFF && segment.start === 0xFFFF);
+        if (includeInCmap4) {
             endCounts.push({name: 'end_' + i, type: 'USHORT', value: segment.end});
             startCounts.push({name: 'start_' + i, type: 'USHORT', value: segment.start});
             idDeltas.push({name: 'idDelta_' + i, type: 'SHORT', value: segment.delta});

--- a/src/tables/cmap.mjs
+++ b/src/tables/cmap.mjs
@@ -290,6 +290,17 @@ function makeCmapTable(glyphs) {
         }
     }
 
+    // Create the CMAP table with some values that still need calculation missing.
+    let cmapTable = [
+        {name: 'version', type: 'USHORT', value: 0},
+        {name: 'numTables', type: 'USHORT', value: null},
+
+        // CMAP 4 header
+        {name: 'platformID', type: 'USHORT', value: 3},
+        {name: 'encodingID', type: 'USHORT', value: 1},
+        {name: 'offset', type: 'ULONG', value: null}
+    ];
+
     // Build and merge segments up front so we can measure the true segment count
     // before committing to a table layout.
     const allSegments = [];
@@ -307,19 +318,16 @@ function makeCmapTable(glyphs) {
     // represent the full mapping without silent truncation.  In that case we fall
     // back to emitting Format 12 for all glyphs, keeping a minimal Format 4
     // subtable (terminator only) for parsers that require its presence.
-    const bmpSegmentCount = mergedSegments.filter(s => s.start <= 0xFFFF).length;
+    let bmpSegmentCount = 0;
+    for (let i = 0; i < mergedSegments.length; i++)
+        if(mergedSegments[i].start <= 0xFFFF)
+            bmpSegmentCount++;
     const cmap4Overflows = bmpSegmentCount > CMAP4_MAX_SEGMENTS;
     isPlan0Only &&= !cmap4Overflows;
 
-    let cmapTable = [
-        {name: 'version', type: 'USHORT', value: 0},
-        {name: 'numTables', type: 'USHORT', value: isPlan0Only ? 1 : 2},
-
-        // CMAP 4 header
-        {name: 'platformID', type: 'USHORT', value: 3},
-        {name: 'encodingID', type: 'USHORT', value: 1},
-        {name: 'offset', type: 'ULONG', value: isPlan0Only ? 12 : (12 + 8)}
-    ];
+    // Fill in missing values in CMAP table
+    cmapTable[1].value = isPlan0Only ? 1 : 2;
+    cmapTable[4].value = isPlan0Only ? 12 : 20;
 
     if (!isPlan0Only)
         cmapTable.push(...[

--- a/src/tables/cmap.mjs
+++ b/src/tables/cmap.mjs
@@ -231,8 +231,8 @@ function parseCmapTable(data, start) {
     return cmap;
 }
 
-function addSegment(t, code, glyphIndex) {
-    t.segments.push({
+function addSegment(segments, code, glyphIndex) {
+    segments.push({
         end: code,
         start: code,
         delta: -(code - glyphIndex),
@@ -273,7 +273,7 @@ function mergeSegments(segments) {
 // Each segment contributes 8 bytes (one entry in each of the four parallel arrays),
 // plus the 14-byte header and the 2-byte reservedPad, leaving room for at most
 // floor((65535 - 16) / 8) = 8189 segments before overflow.
-const CMAP4_MAX_SEGMENTS = Math.floor((0xFFFF - 16) / 8);
+const CMAP4_MAX_SEGMENTS = 8189;
 
 // Make cmap table, format 4 by default, 12 if needed only
 function makeCmapTable(glyphs) {
@@ -296,7 +296,7 @@ function makeCmapTable(glyphs) {
     for (i = 0; i < glyphs.length; i += 1) {
         const glyph = glyphs.get(i);
         for (let j = 0; j < glyph.unicodes.length; j += 1) {
-            addSegment({ segments: allSegments }, glyph.unicodes[j], i);
+            addSegment(allSegments, glyph.unicodes[j], i);
         }
     }
     allSegments.sort(function(a, b) { return a.start - b.start; });
@@ -309,9 +309,7 @@ function makeCmapTable(glyphs) {
     // subtable (terminator only) for parsers that require its presence.
     const bmpSegmentCount = mergedSegments.filter(s => s.start <= 0xFFFF).length;
     const cmap4Overflows = bmpSegmentCount > CMAP4_MAX_SEGMENTS;
-    if (cmap4Overflows) {
-        isPlan0Only = false;
-    }
+    isPlan0Only &&= !cmap4Overflows;
 
     let cmapTable = [
         {name: 'version', type: 'USHORT', value: 0},
@@ -366,11 +364,10 @@ function makeCmapTable(glyphs) {
         const segment = t.segments[i];
 
         // CMAP 4: when the table would overflow, emit only the terminator segment
-        // so that Format 4 remains structurally valid.  All actual mappings are
+        // so that Format 4 remains structurally valid. All actual mappings are
         // carried by the Format 12 subtable in that case.
-        const includeInCmap4 = segment.end <= 65535 && segment.start <= 65535 && !cmap4Overflows ||
-            (cmap4Overflows && segment.end === 0xFFFF && segment.start === 0xFFFF);
-        if (includeInCmap4) {
+        if (segment.end <= 65535 && segment.start <= 65535 && !cmap4Overflows ||
+            (cmap4Overflows && segment.end === 0xFFFF && segment.start === 0xFFFF)) {
             endCounts.push({name: 'end_' + i, type: 'USHORT', value: segment.end});
             startCounts.push({name: 'start_' + i, type: 'USHORT', value: segment.start});
             idDeltas.push({name: 'idDelta_' + i, type: 'SHORT', value: segment.delta});

--- a/src/tables/cmap.mjs
+++ b/src/tables/cmap.mjs
@@ -323,7 +323,7 @@ function makeCmapTable(glyphs) {
         if(mergedSegments[i].start <= 0xFFFF)
             bmpSegmentCount++;
     const cmap4Overflows = bmpSegmentCount > CMAP4_MAX_SEGMENTS;
-    isPlan0Only &&= !cmap4Overflows;
+    isPlan0Only = isPlan0Only && !cmap4Overflows;
 
     // Fill in missing values in CMAP table
     cmapTable[1].value = isPlan0Only ? 1 : 2;

--- a/src/tables/sfnt.mjs
+++ b/src/tables/sfnt.mjs
@@ -37,12 +37,16 @@ function computeCheckSum(bytes) {
     let sum = 0;
     const padded = (bytes.length + 3) & ~3;
     for (let i = 0; i < padded; i += 4) {
+        // Mask each byte to 0xFF: the byte array may contain values > 255 due to
+        // M.CHARARRAY encoding non-ASCII strings with full Unicode codepoints.
+        // Uint8Array (used for file output) truncates to 8 bits, so we must do the
+        // same here to produce a checksum that matches the actual file bytes.
         sum = (sum + (
-            ((bytes[i]     || 0) << 24 |
-             (bytes[i + 1] || 0) << 16 |
-             (bytes[i + 2] || 0) << 8  |
-             (bytes[i + 3] || 0)) >>> 0
-        )) >>> 0;
+            ((bytes[i]     || 0) & 0xFF) << 24 |
+            ((bytes[i + 1] || 0) & 0xFF) << 16 |
+            ((bytes[i + 2] || 0) & 0xFF) << 8  |
+            ((bytes[i + 3] || 0) & 0xFF)
+        ) >>> 0) >>> 0;
     }
     return sum;
 }

--- a/src/tables/sfnt.mjs
+++ b/src/tables/sfnt.mjs
@@ -34,19 +34,16 @@ function log2(v) {
 }
 
 function computeCheckSum(bytes) {
-    while (bytes.length % 4 !== 0) {
-        bytes.push(0);
-    }
-
     let sum = 0;
-    for (let i = 0; i < bytes.length; i += 4) {
-        sum += (bytes[i] << 24) +
-            (bytes[i + 1] << 16) +
-            (bytes[i + 2] << 8) +
-            (bytes[i + 3]);
+    const padded = (bytes.length + 3) & ~3;
+    for (let i = 0; i < padded; i += 4) {
+        sum = (sum + (
+            ((bytes[i]     || 0) << 24 |
+             (bytes[i + 1] || 0) << 16 |
+             (bytes[i + 2] || 0) << 8  |
+             (bytes[i + 3] || 0)) >>> 0
+        )) >>> 0;
     }
-
-    sum %= Math.pow(2, 32);
     return sum;
 }
 

--- a/src/tables/sfnt.mjs
+++ b/src/tables/sfnt.mjs
@@ -394,7 +394,7 @@ function fontToSfntTable(font) {
     let checkSumAdjusted = false;
     for (let i = 0; i < tableFields.length; i += 1) {
         if (tableFields[i].name === 'head table') {
-            tableFields[i].value.checkSumAdjustment = 0xB1B0AFBA - checkSum;
+            tableFields[i].value.checkSumAdjustment = (0xB1B0AFBA - checkSum) >>> 0;
             checkSumAdjusted = true;
             break;
         }

--- a/src/tables/sfnt.mjs
+++ b/src/tables/sfnt.mjs
@@ -42,10 +42,10 @@ function computeCheckSum(bytes) {
         // Uint8Array (used for file output) truncates to 8 bits, so we must do the
         // same here to produce a checksum that matches the actual file bytes.
         sum = (sum + (
-            ((bytes[i]     || 0) & 0xFF) << 24 |
-            ((bytes[i + 1] || 0) & 0xFF) << 16 |
-            ((bytes[i + 2] || 0) & 0xFF) << 8  |
-            ((bytes[i + 3] || 0) & 0xFF)
+            ((bytes[i]     ?? 0) & 0xFF) << 24 |
+            ((bytes[i + 1] ?? 0) & 0xFF) << 16 |
+            ((bytes[i + 2] ?? 0) & 0xFF) << 8  |
+            ((bytes[i + 3] ?? 0) & 0xFF)
         ) >>> 0) >>> 0;
     }
     return sum;

--- a/src/tables/sfnt.mjs
+++ b/src/tables/sfnt.mjs
@@ -43,10 +43,10 @@ function computeCheckSum(bytes) {
         // Uint8Array (used for file output) truncates to 8 bits, so we must do the
         // same here to produce a checksum that matches the actual file bytes.
         sum += (
-            ((bytes[i]     ?? 0) & 0xFF) << 24 |
-            ((bytes[i + 1] ?? 0) & 0xFF) << 16 |
-            ((bytes[i + 2] ?? 0) & 0xFF) << 8  |
-            ((bytes[i + 3] ?? 0) & 0xFF)
+            ((bytes[i]     || 0) & 0xFF) << 24 |
+            ((bytes[i + 1] || 0) & 0xFF) << 16 |
+            ((bytes[i + 2] || 0) & 0xFF) << 8  |
+            ((bytes[i + 3] || 0) & 0xFF)
         ) >>> 0;
     }
     return sum >>> 0;

--- a/src/tables/sfnt.mjs
+++ b/src/tables/sfnt.mjs
@@ -35,20 +35,21 @@ function log2(v) {
 
 function computeCheckSum(bytes) {
     let sum = 0;
+    // This rounds to integer multiples of 4.
     const padded = (bytes.length + 3) & ~3;
     for (let i = 0; i < padded; i += 4) {
         // Mask each byte to 0xFF: the byte array may contain values > 255 due to
         // M.CHARARRAY encoding non-ASCII strings with full Unicode codepoints.
         // Uint8Array (used for file output) truncates to 8 bits, so we must do the
         // same here to produce a checksum that matches the actual file bytes.
-        sum = (sum + (
+        sum += (
             ((bytes[i]     ?? 0) & 0xFF) << 24 |
             ((bytes[i + 1] ?? 0) & 0xFF) << 16 |
             ((bytes[i + 2] ?? 0) & 0xFF) << 8  |
             ((bytes[i + 3] ?? 0) & 0xFF)
-        ) >>> 0) >>> 0;
+        ) >>> 0;
     }
-    return sum;
+    return sum >>> 0;
 }
 
 function makeTableRecord(tag, checkSum, offset, length) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
### Bug: computeCheckSum produces incorrect checksums for tables with non-ASCII data

### Context

I'm Meow P (From @MontageSubs), working on [ASS Subsetter](https://github.com/MontageSubs/ass-subset), a browser-based tool for subsetting fonts embedded in ASS subtitle files. It's built entirely on opentype.js, thank you for this excellent library that made our tool possible. I'm excited to contribute this fix back upstream.

While testing with large CJK CFF fonts (Source Han Sans, Source Han Serif), I found that fonts generated by `toArrayBuffer()` are rejected by Windows Font Viewer and the Windows DWRITE stack, even though they load fine in every media player and browser I tested. That discrepancy made me suspect a structural validation issue rather than a rendering one.



### What's wrong

`computeCheckSum` in `src/tables/sfnt.mjs` has **two separate root causes** that combine to produce incorrect per-table checksums:


#### Bug 1: Signed Integer Overflow in Bit Shifting

JavaScript's `<<` operator always returns a signed 32-bit integer. When the high byte of a 4-byte word is >= 0x80, shifting left by 24 bits produces a negative number:

```javascript
0xFC << 24  // -67108864, not 4227858432
```

The sum accumulates these negative contributions and drifts below zero. The `sum %= Math.pow(2, 32)` does not fix this because JavaScript's remainder operator preserves the sign of the dividend:

```javascript
-67108864 % 4294967296  // still -67108864
```

#### Bug 2: M.CHARARRAY Writes Values > 255 (Root Cause)

M.CHARARRAY encodes strings using `charCodeAt()`, which returns full Unicode codepoints for non-ASCII characters. For example:
- '思' returns `0x601D` (> 255)
- '源' returns `0x6E90` (> 255)

This causes a critical mismatch:

1.`computeCheckSum()` calculates using these raw values (> 255)
2. `Uint8Array` (used for file output) truncates each element to 8 bits when writing:
   - `0x601D` becomes `0x1D`
   - `0x6E90` becomes `0x90`

Since the checksum is computed on untruncated values but the file contains truncated bytes, **the checksums never match**.

Example: For a CFF table with Chinese family name, computeCheckSum produces `0xf1332993`, but the actual file checksum is `0xe290b993`.

#### Additional Issues

- The function mutates the input array directly via `bytes.push(0)`. If the caller's array is reused, subsequent reads include the padding bytes from the first checksum call.
- The checkSumAdjustment calculation can produce a negative result when checkSum > 0xB1B0AFBA, which should be coerced to unsigned 32-bit.

## Why It Shows Up on Large CJK Fonts Specifically

Small subsets tend to pass because the sign errors in individual words partially cancel each other out over short sequences. Once a CFF table is large enough (roughly 800+ glyphs of CJK data), there are enough high-byte words that the accumulated error becomes significant. Windows validates every table checksum strictly; most rendering engines skip the check entirely.

## Fix

Replace computeCheckSum with a version that:
1. Masks each byte to 8-bit (`& 0xFF`) to match Uint8Array truncation
2. Uses `>>> 0` throughout to stay in unsigned 32-bit arithmetic
3. Avoids mutating the input array

```javascript
function computeCheckSum(bytes) {
    let sum = 0;
    const padded = (bytes.length + 3) & ~3;
    for (let i = 0; i < padded; i += 4) {
        sum = (sum + (
            ((bytes[i]     || 0) & 0xFF) << 24 |
            ((bytes[i + 1] || 0) & 0xFF) << 16 |
            ((bytes[i + 2] || 0) & 0xFF) << 8  |
            ((bytes[i + 3] || 0) & 0xFF)
        ) >>> 0) >>> 0;
    }
    return sum;
}
```

And guard checkSumAdjustment against underflow:

```javascript
tableFields[i].value.checkSumAdjustment = (0xB1B0AFBA - checkSum) >>> 0;
```

Verified: patched build produces byte-for-byte matching checksums against fonttools on Source Han Sans subsets of 1200+ glyphs where the original was broken.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


Apply the fix and test it in my tools:

**Stable deployment** (without this fix, using internal workaround):
https://subs.js.org/ass-subset/
https://github.com/MontageSubs/ass-subset/

**Test deployment** (with this fix applied):
https://mtsubs.github.io/ass-subset/
https://github.com/mtsubs/ass-subset/

Test fonts:
- https://github.com/adobe-fonts/source-han-serif/releases
- https://github.com/adobe-fonts/source-han-sans/releases

**Note:** Our tools tested against opentype.js 1.3.4. The GitHub version has API changes (e.g., fontFamily naming structure) that we have not yet adapted to.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [X] I have read the **Contribute** README section.
