### PR TITLE
Harden release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
-    - run: npm install
+        node-version: 22
+    - run: npm ci
     - run: npm run build
     - run: npm run dist
     - run: npm run test

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 22
-    - run: npm install
+    - run: npm ci
     - run: npm run build
     - run: npm run dist
     - run: mv dist docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,93 @@
 name: Publish package to npm
-run-name: npm - publish ${{ github.event.inputs.version }} to ${{ github.event.inputs.npmDistTag }}
+run-name: npm - publish ${{ inputs.version }} to ${{ inputs.npmDistTag }}
 
 on:
   workflow_dispatch:
     inputs:
       version:
         required: true
-        description: 'SemVer version for npm. (i.e. 1.0.0)'
+        description: 'SemVer version for npm. (i.e. 1.3.5)'
       npmDistTag:
         required: true
         default: 'latest'
+        type: choice
+        options:
+        - latest
+        - next
+        - beta
       dryRun:
         description: 'Do a dry run (does not publish packages)'
         type: boolean
+        default: true
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
 
 jobs:
   publish:
     timeout-minutes: 25
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
+      contents: write
       # required for publishing to npm with --provenance
       # see https://docs.npmjs.com/generating-provenance-statements
       id-token: write
     steps:
     - name: Print input
       env:
-        THE_INPUT: '${{ toJson(github.event.inputs) }}'
+        THE_INPUT: '${{ toJson(inputs) }}'
       run: |
         echo $THE_INPUT
         
     - uses: actions/checkout@v4
-    
-    - uses: actions/setup-node@v3
       with:
-        node-version: 20
+        fetch-depth: 0
+    
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
         registry-url: 'https://registry.npmjs.org'
     
+    - name: Preflight checks
+      env:
+        VERSION: ${{ inputs.version }}
+        NPM_DIST_TAG: ${{ inputs.npmDistTag }}
+        DRY_RUN: ${{ inputs.dryRun }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+
+        if ! node -e "const v = process.env.VERSION; if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(v)) process.exit(1);"; then
+          echo "::error::Version '$VERSION' is not valid SemVer."
+          exit 1
+        fi
+
+        case "$NPM_DIST_TAG" in
+          latest|next|beta) ;;
+          *)
+            echo "::error::npmDistTag '$NPM_DIST_TAG' is not allowed."
+            exit 1
+            ;;
+        esac
+
+        git fetch --tags --force
+        if git rev-parse --verify --quiet "refs/tags/$VERSION"; then
+          echo "::error::Git tag '$VERSION' already exists."
+          exit 1
+        fi
+
+        if npm view "opentype.js@$VERSION" version >/dev/null 2>&1; then
+          echo "::error::npm version '$VERSION' already exists."
+          exit 1
+        fi
+
+        if [ "$DRY_RUN" != "true" ] && [ "$REF_NAME" != "master" ]; then
+          echo "::error::Real releases must run from the master branch."
+          exit 1
+        fi
+
     - name: Install dependencies
       run: npm ci
     
@@ -49,12 +101,30 @@ jobs:
       run: npm run test
     
     - name: Set version in package*.json
-      run: npm pkg set version=${{ github.event.inputs.version }}
+      run: npm pkg set version=${{ inputs.version }}
     
     - name: Publish package to npm
-      run: npm publish --access public --tag ${{ github.event.inputs.npmDistTag }} ${{ env.DRY_RUN }}
+      run: npm publish --access public --tag ${{ inputs.npmDistTag }} ${{ env.DRY_RUN }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         # https://docs.npmjs.com/generating-provenance-statements
         NPM_CONFIG_PROVENANCE: true
-        DRY_RUN: ${{ github.event.inputs.dryRun == 'true' && '--dry-run' || '' }}
+        DRY_RUN: ${{ inputs.dryRun && '--dry-run' || '' }}
+
+    - name: Create git tag
+      if: ${{ !inputs.dryRun }}
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git tag "$VERSION"
+        git push origin "$VERSION"
+
+    - name: Create GitHub release
+      if: ${{ !inputs.dryRun }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ inputs.version }}
+      run: gh release create "$VERSION" --title "$VERSION" --generate-notes

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ If you plan on improving or debugging opentype.js, you can:
 - check if all still works fine with `npm run test`
 - commit and open a Pull Request with your changes. Thank you!
 
+## Maintainer Releases
+
+Releases are published from the manual [Publish package to npm](https://github.com/opentypejs/opentype.js/actions/workflows/release.yml) workflow.
+
+1. Confirm the target version, for example `1.3.5`, and make sure `master` is green.
+2. Run the workflow from `master` with `dryRun: true` and `npmDistTag: latest`.
+3. Inspect the dry-run output, especially the package version and packed files.
+4. Re-run the workflow with the same version and `dryRun: false`.
+
+The release workflow runs preflight checks, publishes to npm, then creates the matching git tag and GitHub release.
+
 ## Usage
 
 ### Loading a WOFF/OTF/TTF font


### PR DESCRIPTION
## Description

Currently, the workflow to create a release is to use a specific GH action that automates the process and tries to avoid issues. This PR fixes this and adds some extra checks:

- Modernize actions (use newer versions)
- Use `npm ci` instead of `npm install` (makes sure we use the exact packages as specified in `package-lock.json`

When running:

- Check that there is no release running concurrently (very niche, but good to check)
- Check that the version does not exist yet on npm or as a git tag
- Also create a git tag + GitHub release

## Motivation and Context

I've added this to make sure releases are foolproof (the fool being me)

## How Has This Been Tested?

By looking over the code carefully; we can't test this unless by running a release, or doing a dry-run (but that means we first need to merge this PR)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the **README** accordingly.
- [x] I have read the **Contribute** README section.
