### PR TITLE
Use trusted npm publishing for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: 22
     - run: npm ci

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -14,8 +14,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: 22
     - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,11 @@ jobs:
       run: |
         echo $THE_INPUT
         
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     
     - uses: actions/setup-node@v5
       with:
-        node-version: 22
+        node-version: 24
         registry-url: 'https://registry.npmjs.org'
 
     - name: Upgrade npm for trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
       with:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
+
+    - name: Upgrade npm for trusted publishing
+      run: npm install -g npm@latest
     
     - name: Preflight checks
       env:
@@ -106,9 +109,6 @@ jobs:
     - name: Publish package to npm
       run: npm publish --access public --tag ${{ inputs.npmDistTag }} ${{ env.DRY_RUN }}
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        # https://docs.npmjs.com/generating-provenance-statements
-        NPM_CONFIG_PROVENANCE: true
         DRY_RUN: ${{ inputs.dryRun && '--dry-run' || '' }}
 
     - name: Create git tag


### PR DESCRIPTION
## Summary

To make a new release of OpenType.js, we want to use npmjs' [trusted publishing](https://docs.npmjs.com/trusted-publishers). That means we don't rely on secrets in our repo anymore, but we make a direct link between the two that does the auth. 

- Switch the npm release workflow to trusted publishing by removing the long-lived npm token and explicit provenance config.
- Upgrade npm before publishing and run releases on Node 24.

## Test plan
- [x] Checked workflow diff.
- [x] Checked workflow file diagnostics.
- [ ] Run the release workflow dry run in GitHub Actions.
