### PR TITLE
Fix for v2.0.0 SVG y-axis flipping bug

### DIFF
--- a/src/font.mjs
+++ b/src/font.mjs
@@ -444,6 +444,8 @@ Font.prototype.getPath = function(text, x, y, fontSize, options) {
         }
         fullPath.extend(glyphPath);
     });
+    // mark as y-coordinates as flipped
+    fullPath.isFlipped = true;
     return fullPath;
 };
 

--- a/src/glyph.mjs
+++ b/src/glyph.mjs
@@ -237,6 +237,12 @@ Glyph.prototype.getPath = function(x, y, fontSize, options, font) {
         }
     }
 
+    /**
+     * mark Path object as flipped for 
+     * subsequent SVG pathData methods
+     */
+    p.isFlipped = true;
+
     return p;
 };
 

--- a/src/path.mjs
+++ b/src/path.mjs
@@ -600,7 +600,7 @@ Path.prototype.toPathData = function(options) {
         commandsCopy = optimizeCommands(commandsCopy);
     }
 
-    const flipY = options.flipY;
+    const flipY = (this.isFlipped===undefined && options.flipY) || (!options.flipY && this.isFlipped );
     let flipYBase = options.flipYBase;
     if (flipY === true && flipYBase === undefined) {
         const tempPath = new Path();


### PR DESCRIPTION
## Description
This pull request is an proposal to fix the current bug with y-axis flipping necessary for SVG rendering. 
Opentype's  native coordinate system uses a traditional Cartesian y-axis direction (bottom-to-top) while SVG requires a top-to-bottom conversion (as well as canvas path2D methods) . 

### Double y-axis flipping in v2
By default, all SVG related  functions correctly convert "flip" the y-axis. 
However, we have a duplicate conversion in methods such as `Path.prototype.toPathData`.  

`toPathData()`  expects/accepts a an `options.flipY` parameter 
but it **doesn't detect previously applied coordinate conversions** e.g via `Glyph.prototype.getPath`.  

## Motivation and Context
The current v2 API breaks the expected v1.3.4 y-flipping logic necessary for SVG renderings.  

This is a fix proposal for filed issue #724 ["SVG related y-Axis conversion differs in version 2.0.0"](https://github.com/opentypejs/opentype.js/issues/724)

## How Has This Been Tested?
Tested with multiple font files and SVG related rendering chains: 
* `font.getPath()`  and manual pathdata stringification from Path commands property
* `font.getPath()`  standard pathdata stringification via `toPathData()` – testing explicit `{flipY:true}` , `{flipY:false}` or empty default
* `font.getPaths()`  – concatenated pathData from individual glyph Path objects  
* `path.toSVG()` – return markup for SVG `<path>` element
* `font.stringToGlyphs()`  and concatenated pathData from individual glyph objects

Codepen examples:  
* ["Opentype.js v2.0.0 – SVG y-axis flipping (main dist)"](https://codepen.io/herrstrietzel/pen/GgNMZEP) – unchanged/main dist
* ["Opentype.js v2.0.0 – SVG y-axis flipping (forked)"](https://codepen.io/herrstrietzel/pen/pvNWyPj) – fix proposal


## Types of changes
The proposal mainly adds a `isFlipped` property to the `Path` object to detect already applied coordinate transformations.  

Affected  are:  
* font.mjs: `Font.prototype.getPath`  – `isFlipped` property
* glyph.mjs: `Glyph.prototype.getPath`  – `isFlipped` property
* path.mjs: `Path.prototype.toPathData` – disable `flipY` when `isFlipped` is true/defined


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I did `npm run test` and all tests passed green (including code styling checks).
All tests are finished successfully excepts "tables/cff.mjs handles PaintType and StrokeWidth" which returns flipped y-coordinates which should be expected since the y-flipping is not correct in the current implementation?
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **Contribute** README section.  


If I missed any aspects please feel free to ask for clarification or improvements. 
The current y-flipping behavior is actually a rather trivial bug but it's critical for anyone using opentype.js to generate SVG outputs.  

You may also consider to set a hardcoded/non-editable "auto-y-flip" by default for SVG related output methods but on the other hand there are also applications or other vector environments such as PDF which also use a traditional Cartesian Y-Axis direction – so maintaining all flexibility makes sense.
