### PR TITLE
Automatically generate Closure compiler types.

### DIFF
--- a/externs/opentype.js
+++ b/externs/opentype.js
@@ -1,26 +1,143 @@
 /**
- * @fileoverview Closure Compiler externs for opentype.js version.
- * @see http://opentype.js.org/
+ * @fileoverview Closure Compiler externs for opentype.js generated from source JSDoc.
  * @externs
  */
 
 /** @const */
 var opentype = {};
+
 /**
  * A Font represents a loaded OpenType font file.
  * It contains a set of glyphs and methods to draw text on a drawing context,
  * or to get a path representing the text.
+ * @exports opentype.Font
+ * @class
  * @param {FontOptions}
  * @constructor
  */
-opentype.Font = function(options) {};
+opentype.Font = function() {};
+
+/**
+ * @exports opentype.Glyph
+ * @class
+ * @param {GlyphOptions}
+ * @constructor
+ */
+opentype.Glyph = function() {};
+
+/**
+ * A bézier path containing a set of path commands similar to a SVG path.
+ * Paths can be drawn on a context using `draw`.
+ * @exports opentype.Path
+ * @class
+ * @constructor
+ */
+opentype.Path = function() {};
+
+/**
+ * A bounding box is an enclosing box that describes the smallest measure within which all the points lie.
+ * It is used to calculate the bounding box of a glyph or text path.
+ *
+ * On initialization, x1/y1/x2/y2 will be NaN. Check if the bounding box is empty using `isEmpty()`.
+ *
+ * @exports opentype.BoundingBox
+ * @class
+ * @constructor
+ */
+opentype.BoundingBox = function() {};
+
+/** @type {?} */
+opentype._parse = function() {};
+
+/**
+ * Parse the OpenType file data (as an ArrayBuffer) and return a Font object.
+ * Throws an error if the font could not be parsed.
+ * @param  {ArrayBuffer}
+ * @param  {Object} opt - options for parsing
+ * @return {opentype.Font}
+ */
+opentype.parse = function() {};
+
+/**
+ * Asynchronously load the font from a URL or a filesystem. When done, call the callback
+ * with two arguments `(err, font)`. The `err` will be null on success,
+ * the `font` is a Font object.
+ * We use the node.js callback convention so that
+ * opentype.js can integrate with frameworks like async.js.
+ * @alias opentype.load
+ * @deprecated
+ */
+opentype.load = function() {};
+
+/**
+ * Synchronously load the font from a URL or file.
+ * When done, returns the font object or throws an error.
+ * @alias opentype.loadSync
+ * @deprecated
+ */
+opentype.loadSync = function() {};
+
+/**
+ * Returns true if the bounding box is empty, that is, no points have been added to the box yet.
+ */
+opentype.BoundingBox.prototype.isEmpty = function() {};
+
+/**
+ * Add the point to the bounding box.
+ * The x1/y1/x2/y2 coordinates of the bounding box will now encompass the given point.
+ * @param {number} x - The X coordinate of the point.
+ * @param {number} y - The Y coordinate of the point.
+ */
+opentype.BoundingBox.prototype.addPoint = function() {};
+
+/**
+ * Add a X coordinate to the bounding box.
+ * This extends the bounding box to include the X coordinate.
+ * This function is used internally inside of addBezier.
+ * @param {number} x - The X coordinate of the point.
+ */
+opentype.BoundingBox.prototype.addX = function() {};
+
+/**
+ * Add a Y coordinate to the bounding box.
+ * This extends the bounding box to include the Y coordinate.
+ * This function is used internally inside of addBezier.
+ * @param {number} y - The Y coordinate of the point.
+ */
+opentype.BoundingBox.prototype.addY = function() {};
+
+/**
+ * Add a Bézier curve to the bounding box.
+ * This extends the bounding box to include the entire Bézier.
+ * @param {number} x0 - The starting X coordinate.
+ * @param {number} y0 - The starting Y coordinate.
+ * @param {number} x1 - The X coordinate of the first control point.
+ * @param {number} y1 - The Y coordinate of the first control point.
+ * @param {number} x2 - The X coordinate of the second control point.
+ * @param {number} y2 - The Y coordinate of the second control point.
+ * @param {number} x - The ending X coordinate.
+ * @param {number} y - The ending Y coordinate.
+ */
+opentype.BoundingBox.prototype.addBezier = function() {};
+
+/**
+ * Add a quadratic curve to the bounding box.
+ * This extends the bounding box to include the entire quadratic curve.
+ * @param {number} x0 - The starting X coordinate.
+ * @param {number} y0 - The starting Y coordinate.
+ * @param {number} x1 - The X coordinate of the control point.
+ * @param {number} y1 - The Y coordinate of the control point.
+ * @param {number} x - The ending X coordinate.
+ * @param {number} y - The ending Y coordinate.
+ */
+opentype.BoundingBox.prototype.addQuad = function() {};
 
 /**
  * Check if the font has a glyph for the given character.
  * @param  {string}
  * @return {Boolean}
  */
-opentype.Font.prototype.hasChar = function(c) {};
+opentype.Font.prototype.hasChar = function() {};
 
 /**
  * Convert the given character to a single glyph index.
@@ -29,67 +146,104 @@ opentype.Font.prototype.hasChar = function(c) {};
  * @param  {string}
  * @return {Number}
  */
-opentype.Font.prototype.charToGlyphIndex = function(s) {};
+opentype.Font.prototype.charToGlyphIndex = function() {};
 
 /**
  * Convert the given character to a single Glyph object.
  * Note that this function assumes that there is a one-to-one mapping between
  * the given character and a glyph; for complex scripts this might not be the case.
- * @param  {string} c
+ * @param  {string}
  * @return {opentype.Glyph}
  */
-opentype.Font.prototype.charToGlyph = function(c) {};
+opentype.Font.prototype.charToGlyph = function() {};
+
+/**
+ * Update features
+ * @param {any} options features options
+ */
+opentype.Font.prototype.updateFeatures = function() {};
+
+/**
+ * Convert the given text to a list of Glyph indexes.
+ * Note that there is no strict one-to-one mapping between characters and
+ * glyphs, so the list of returned glyph indexes can be larger or smaller than the
+ * length of the given string.
+ * @param  {string}
+ * @param  {GlyphRenderOptions} [options]
+ * @return {number[]}
+ */
+opentype.Font.prototype.stringToGlyphIndexes = function() {};
 
 /**
  * Convert the given text to a list of Glyph objects.
  * Note that there is no strict one-to-one mapping between characters and
  * glyphs, so the list of returned glyphs can be larger or smaller than the
  * length of the given string.
- * @param  {string} s
- * @param  {Object=} options
+ * @param  {string}
+ * @param  {GlyphRenderOptions} [options]
  * @return {opentype.Glyph[]}
  */
-opentype.Font.prototype.stringToGlyphs = function(s, options) {};
+opentype.Font.prototype.stringToGlyphs = function() {};
 
 /**
  * @param  {string}
  * @return {Number}
  */
-opentype.Font.prototype.nameToGlyphIndex = function(name) {};
+opentype.Font.prototype.nameToGlyphIndex = function() {};
 
 /**
  * @param  {string}
  * @return {opentype.Glyph}
  */
-opentype.Font.prototype.nameToGlyph = function(name) {};
+opentype.Font.prototype.nameToGlyph = function() {};
 
 /**
  * @param  {Number}
  * @return {String}
  */
-opentype.Font.prototype.glyphIndexToName = function(gid) {};
+opentype.Font.prototype.glyphIndexToName = function() {};
 
 /**
  * Retrieve the value of the kerning pair between the left glyph (or its index)
  * and the right glyph (or its index). If no kerning pair is found, return 0.
  * The kerning value gets added to the advance width when calculating the spacing
  * between glyphs.
+ * For GPOS kerning, this method uses the default script and language, which covers
+ * most use cases. To have greater control, use font.position.getKerningValue .
  * @param  {opentype.Glyph} leftGlyph
  * @param  {opentype.Glyph} rightGlyph
  * @return {Number}
  */
-opentype.Font.prototype.getKerningValue = function(leftGlyph, rightGlyph) {};
+opentype.Font.prototype.getKerningValue = function() {};
+
+/**
+ * @typedef GlyphRenderOptions
+ * @type Object
+ * @property {string} [script] - script used to determine which features to apply. By default, 'DFLT' or 'latn' is used.
+ *                               See https://www.microsoft.com/typography/otspec/scripttags.htm
+ * @property {string} [language='dflt'] - language system used to determine which features to apply.
+ *                                        See https://www.microsoft.com/typography/developers/opentype/languagetags.aspx
+ * @property {boolean} [kerning=true] - whether to include kerning values
+ * @property {object} [features] - OpenType Layout feature tags. Used to enable or disable the features of the given script/language system.
+ *                                 See https://www.microsoft.com/typography/otspec/featuretags.htm
+ * @property {boolean} [hinting=false] - whether to apply font hinting to the outlines
+ * @property {integer} [usePalette=0] For COLR/CPAL fonts, the zero-based index of the color palette to use. (Use `Font.palettes.get()` to get the available palettes)
+ * @property {boolean} [drawLayers=true] For COLR/CPAL fonts, this can be turned to false in order to draw the fallback glyphs instead
+ * @property {boolean} [drawSVG=true] For SVG fonts, this can be turned to false in order to draw the fallback glyphs instead
+ */
+opentype.Font.prototype.defaultRenderOptions = function() {};
 
 /**
  * Helper function that invokes the given callback for each glyph in the given text.
- * The callback gets `(glyph, x, y, fontSize, options)`.* @param  {string} text
- * @param  {number} x - Horizontal position of the beginning of the text.
- * @param  {number} y - Vertical position of the *baseline* of the text.
- * @param  {number} fontSize - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
- * @param  {Object} options
+ * The callback gets `(glyph, x, y, fontSize, options)`.
+ * @param {string} text - The text to apply.
+ * @param  {number} [x=0] - Horizontal position of the beginning of the text.
+ * @param  {number} [y=0] - Vertical position of the *baseline* of the text.
+ * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
+ * @param  {GlyphRenderOptions=} options
  * @param  {Function} callback
  */
-opentype.Font.prototype.forEachGlyph = function(text, x, y, fontSize, options, callback) {};
+opentype.Font.prototype.forEachGlyph = function() {};
 
 /**
  * Create a Path object that represents the given text.
@@ -97,21 +251,38 @@ opentype.Font.prototype.forEachGlyph = function(text, x, y, fontSize, options, c
  * @param  {number} [x=0] - Horizontal position of the beginning of the text.
  * @param  {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
- * @param  {Object=} options
+ * @param  {GlyphRenderOptions=} options
  * @return {opentype.Path}
  */
-opentype.Font.prototype.getPath = function(text, x, y, fontSize, options) {};
+opentype.Font.prototype.getPath = function() {};
 
 /**
- * Create an array of Path objects that represent the glyps of a given text.
+ * Create an array of Path objects that represent the glyphs of a given text.
  * @param  {string} text - The text to create.
  * @param  {number} [x=0] - Horizontal position of the beginning of the text.
  * @param  {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
- * @param  {Object=} options
+ * @param  {GlyphRenderOptions=} options
  * @return {opentype.Path[]}
  */
-opentype.Font.prototype.getPaths = function(text, x, y, fontSize, options) {};
+opentype.Font.prototype.getPaths = function() {};
+
+/**
+ * Returns the advance width of a text.
+ *
+ * This is something different than Path.getBoundingBox() as for example a
+ * suffixed whitespace increases the advanceWidth but not the bounding box
+ * or an overhanging letter like a calligraphic 'f' might have a quite larger
+ * bounding box than its advance width.
+ *
+ * This corresponds to canvas2dContext.measureText(text).width
+ *
+ * @param  {string} text - The text to create.
+ * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
+ * @param  {GlyphRenderOptions=} options
+ * @return advance width
+ */
+opentype.Font.prototype.getAdvanceWidth = function() {};
 
 /**
  * Draw the text on the given drawing context.
@@ -120,9 +291,9 @@ opentype.Font.prototype.getPaths = function(text, x, y, fontSize, options) {};
  * @param  {number} [x=0] - Horizontal position of the beginning of the text.
  * @param  {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
- * @param  {Object=} options
+ * @param  {GlyphRenderOptions=} options
  */
-opentype.Font.prototype.draw = function(ctx, text, x, y, fontSize, options) {};
+opentype.Font.prototype.draw = function() {};
 
 /**
  * Draw the points of all glyphs in the text.
@@ -132,9 +303,9 @@ opentype.Font.prototype.draw = function(ctx, text, x, y, fontSize, options) {};
  * @param {number} [x=0] - Horizontal position of the beginning of the text.
  * @param {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
- * @param {Object=} options
+ * @param {GlyphRenderOptions=} options
  */
-opentype.Font.prototype.drawPoints = function(ctx, text, x, y, fontSize, options) {};
+opentype.Font.prototype.drawPoints = function() {};
 
 /**
  * Draw lines indicating important font measurements for all glyphs in the text.
@@ -146,41 +317,15 @@ opentype.Font.prototype.drawPoints = function(ctx, text, x, y, fontSize, options
  * @param {number} [x=0] - Horizontal position of the beginning of the text.
  * @param {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
- * @param {Object=} options
+ * @param {GlyphRenderOptions=} options
  */
-opentype.Font.prototype.drawMetrics = function(ctx, text, x, y, fontSize, options) {};
+opentype.Font.prototype.drawMetrics = function() {};
 
 /**
  * @param  {string}
  * @return {string}
  */
-opentype.Font.prototype.getEnglishName = function(name) {};
-
-/**
- * @typedef {{
-        fontFamily: Object<string,string>,
-        fontSubfamily: Object<string,string>,
-        fullName: Object<string,string>,
-        // postScriptName may not contain any whitespace
-        postScriptName: Object<string,string>,
-        designer: Object<string,string>,
-        designerURL: Object<string,string>,
-        manufacturer: Object<string,string>,
-        manufacturerURL: Object<string,string>,
-        license: Object<string,string>,
-        licenseURL: Object<string,string>,
-        version: Object<string,string>,
-        description: Object<string,string>,
-        copyright: Object<string,string>,
-        trademark: Object<string,string>
-    };}
- */
-var NamePlatform;
-
-/**
- * @type {{unicode: ?NamePlatform, macintosh: ?NamePlatform, windows: ?NamePlatform}}
- */
-opentype.Font.prototype.names = {};
+opentype.Font.prototype.getEnglishName = function() {};
 
 /**
  * Validate
@@ -193,10 +338,12 @@ opentype.Font.prototype.validate = function() {};
  * @return {opentype.Table}
  */
 opentype.Font.prototype.toTables = function() {};
+
 /**
  * @deprecated Font.toBuffer is deprecated. Use Font.toArrayBuffer instead.
  */
 opentype.Font.prototype.toBuffer = function() {};
+
 /**
  * Converts a `opentype.Font` into an `ArrayBuffer`
  * @return {ArrayBuffer}
@@ -205,25 +352,19 @@ opentype.Font.prototype.toArrayBuffer = function() {};
 
 /**
  * Initiate a download of the OpenType font.
- * @param {string=} fileName
+ * @deprecated
  */
-opentype.Font.prototype.download = function(fileName) {};
+opentype.Font.prototype.download = function() {};
 
-// A Glyph is an individual mark that often corresponds to a character.
-// Some glyphs, such as ligatures, are a combination of many characters.
-// Glyphs are the basic building blocks of a font.
-//
-// The `Glyph` class contains utility methods for drawing the path and its points.
 /**
- * @param {GlyphOptions}
- * @constructor
+ * @param  {GlyphOptions}
  */
-opentype.Glyph = function(options) {};
+opentype.Glyph.prototype.bindConstructorValues = function() {};
 
 /**
  * @param {number}
  */
-opentype.Glyph.prototype.addUnicode = function(unicode) {};
+opentype.Glyph.prototype.addUnicode = function() {};
 
 /**
  * Calculate the minimum bounding box for this glyph.
@@ -236,15 +377,30 @@ opentype.Glyph.prototype.getBoundingBox = function() {};
  * @param  {number} [x=0] - Horizontal position of the beginning of the text.
  * @param  {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
- * @param  {Object=} options - xScale, yScale to strech the glyph.
+ * @param  {GlyphRenderOptions=} options - xScale, yScale to stretch the glyph.
+ * @param  {opentype.Font} font if hinting is to be used, or CPAL/COLR / variation needs to be rendered, the font
  * @return {opentype.Path}
  */
-opentype.Glyph.prototype.getPath = function(x, y, fontSize, options) {};
+opentype.Glyph.prototype.getPath = function() {};
+
+/**
+ * 
+ * @param {opentype.Font} font 
+ * @returns {Array}
+ */
+opentype.Glyph.prototype.getLayers = function() {};
+
+/**
+ * @param {opentype.Font} font
+ * @returns {import('./svgimages.mjs').SVGImage | undefined}
+ */
+opentype.Glyph.prototype.getSvgImage = function() {};
 
 /**
  * Split the glyph into contours.
  * This function is here for backwards compatibility, and to
  * provide raw access to the TrueType glyph outlines.
+ * @param {Array|null} [transformedPoints=null] Use the supplied transformed points from a glyph variation instead of the regular glyph points
  * @return {Array}
  */
 opentype.Glyph.prototype.getContours = function() {};
@@ -261,9 +417,10 @@ opentype.Glyph.prototype.getMetrics = function() {};
  * @param  {number} [x=0] - Horizontal position of the beginning of the text.
  * @param  {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
- * @param  {Object=} options - xScale, yScale to strech the glyph.
+ * @param  {Object=} options - xScale, yScale to stretch the glyph.
+ * @param  {opentype.Font} font - if hinting is to be used, or CPAL/COLR / variation needs to be rendered, the font
  */
-opentype.Glyph.prototype.draw = function(ctx, x, y, fontSize, options) {};
+opentype.Glyph.prototype.draw = function() {};
 
 /**
  * Draw the points of the glyph.
@@ -272,8 +429,10 @@ opentype.Glyph.prototype.draw = function(ctx, x, y, fontSize, options) {};
  * @param  {number} [x=0] - Horizontal position of the beginning of the text.
  * @param  {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
+ * @param  {GlyphRenderOptions=} options
+ * @param  {opentype.Font} font - used to get the default render options, may be needed for variable fonts in the future
  */
-opentype.Glyph.prototype.drawPoints = function(ctx, x, y, fontSize) {};
+opentype.Glyph.prototype.drawPoints = function() {};
 
 /**
  * Draw lines indicating important font measurements.
@@ -285,29 +444,223 @@ opentype.Glyph.prototype.drawPoints = function(ctx, x, y, fontSize) {};
  * @param  {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
  */
-opentype.Glyph.prototype.drawMetrics = function(ctx, x, y, fontSize) {};
+opentype.Glyph.prototype.drawMetrics = function() {};
 
 /**
- * A bézier path containing a set of path commands similar to a SVG path.
- * Paths can be drawn on a context using `draw`.
- * @constructor
+ * Convert the Glyph's Path to a string of path data instructions
+ * @param  {object|number} [options={decimalPlaces:2, optimize:true, variation:undefined}] - Options object (or amount of decimal places for floating-point values for backwards compatibility)
+ * @param  {opentype.Font} font - A font object is required if variation is to be applied in order to get the variation data from the tables
+ * @return {string}
+ * @see Path.toPathData
  */
-opentype.Path = function() {};
+opentype.Glyph.prototype.toPathData = function() {};
 
 /**
- * @param  {number} x
- * @param  {number} y
+ * Sets the path data from an SVG path element or path notation
+ * @param  {string|SVGPathElement}
+ * @param  {object}
  */
-opentype.Path.prototype.moveTo = function(x, y) {};
+opentype.Glyph.prototype.fromSVG = function() {};
 
 /**
- * @param  {number} x
- * @param  {number} y
+ * Convert the Glyph's Path to an SVG <path> element, as a string.
+ * @param  {object|number} [options={decimalPlaces:2, optimize:true, variation:undefined}] - Options object (or amount of decimal places for floating-point values for backwards compatibility)
+ * @param  {opentype.Font} font - A font object is required if variation is to be applied in order to get the variation data from the tables 
+ * @return {string}
  */
-opentype.Path.prototype.lineTo = function(x, y) {};
+opentype.Glyph.prototype.toSVG = function() {};
+
+/**
+ * Convert the path to a DOM element.
+ * @param  {object|number} [options={decimalPlaces:2, optimize:true, variation:undefined}] - Options object (or amount of decimal places for floating-point values for backwards compatibility)
+ * @param  {opentype.Font} font - A font object is required if variation is to be applied in order to get the variation data from the tables 
+ * @return {SVGPathElement}
+ */
+opentype.Glyph.prototype.toDOMElement = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseByte = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseChar = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseCard8 = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseUShort = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseCard16 = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseSID = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseOffset16 = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseShort = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseF2Dot14 = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseUInt24 = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseULong = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseLong = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseOffset32 = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseFixed = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseString = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseTag = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseLongDateTime = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseVersion = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.skip = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseULongList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseUShortList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseOffset16List = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseShortList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseByteList = function() {};
+
+/**
+ * Parse a list of items.
+ * Record count is optional, if omitted it is read from the stream.
+ * itemCallback is one of the Parser methods.
+ */
+opentype._parse.prototype.parseList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseList32 = function() {};
+
+/**
+ * Parse a list of records.
+ * Record count is optional, if omitted it is read from the stream.
+ * Example of recordDescription: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
+ */
+opentype._parse.prototype.parseRecordList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseRecordList32 = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseTupleRecords = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseStruct = function() {};
+
+/**
+ * Parse a GPOS valueRecord
+ * https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#value-record
+ * valueFormat is optional, if omitted it is read from the stream.
+ */
+opentype._parse.prototype.parseValueRecord = function() {};
+
+/**
+ * Parse a list of GPOS valueRecords
+ * https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#value-record
+ * valueFormat and valueCount are read from the stream.
+ */
+opentype._parse.prototype.parseValueRecordList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parsePointer = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parsePointer32 = function() {};
+
+/**
+ * Parse a list of offsets to lists of 16-bit integers,
+ * or a list of offsets to lists of offsets to any kind of items.
+ * If itemCallback is not provided, a list of list of UShort is assumed.
+ * If provided, itemCallback is called on each item and must parse the item.
+ * See examples in tables/gsub.mjs
+ */
+opentype._parse.prototype.parseListOfLists = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseCoverage = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseClassDef = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseScriptList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseFeatureList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseLookupList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseFeatureVariationsList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseVariationStore = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseItemVariationStore = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseVariationRegionList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseItemVariationSubtable = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseDeltaSetIndexMap = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseDeltaSets = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseTupleVariationStoreList = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseTupleVariationStore = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parseTupleVariationHeader = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parsePackedPointNumbers = function() {};
+
+/** @type {?} */
+opentype._parse.prototype.parsePackedDeltas = function() {};
 
 /**
  * Draws cubic curve
+ * @function
+ * curveTo
+ * @memberof opentype.Path.prototype
  * @param  {number} x1 - x of control 1
  * @param  {number} y1 - y of control 1
  * @param  {number} x2 - x of control 2
@@ -315,52 +668,122 @@ opentype.Path.prototype.lineTo = function(x, y) {};
  * @param  {number} x - x of path point
  * @param  {number} y - y of path point
  */
-opentype.Path.prototype.curveTo = function(x1, y1, x2, y2, x, y) {};
+opentype.Path.prototype.
+curveTo = function() {};
 
 /**
  * Draws cubic curve
+ * @function
+ * bezierCurveTo
+ * @memberof opentype.Path.prototype
  * @param  {number} x1 - x of control 1
  * @param  {number} y1 - y of control 1
  * @param  {number} x2 - x of control 2
  * @param  {number} y2 - y of control 2
  * @param  {number} x - x of path point
  * @param  {number} y - y of path point
+ * @see curveTo
  */
-opentype.Path.prototype.bezierCurveTo = function(x1, y1, x2, y2, x, y) {};
+opentype.Path.prototype.
+bezierCurveTo = function() {};
 
 /**
  * Draws quadratic curve
+ * @function
+ * quadraticCurveTo
+ * @memberof opentype.Path.prototype
  * @param  {number} x1 - x of control
  * @param  {number} y1 - y of control
  * @param  {number} x - x of path point
  * @param  {number} y - y of path point
  */
-opentype.Path.prototype.quadTo = function(x1, y1, x, y) {};
+opentype.Path.prototype.
+quadraticCurveTo = function() {};
 
 /**
  * Draws quadratic curve
+ * @function
+ * quadTo
+ * @memberof opentype.Path.prototype
  * @param  {number} x1 - x of control
  * @param  {number} y1 - y of control
  * @param  {number} x - x of path point
  * @param  {number} y - y of path point
  */
-opentype.Path.prototype.quadraticCurveTo = function(x1, y1, x, y) {};
+opentype.Path.prototype.
+quadTo = function() {};
+
+/**
+ * Closes the path
+ * @function closePath
+ * @memberof opentype.Path.prototype
+ */
+opentype.Path.prototype.closePath = function() {};
 
 /**
  * Close the path
+ * @function close
+ * @memberof opentype.Path.prototype
  */
 opentype.Path.prototype.close = function() {};
 
 /**
- * Closes the path
+ * Sets the path data from an SVG path element or path notation
+ * @param  {string|SVGPathElement}
+ * @param  {object}
  */
-opentype.Path.prototype.closePath = function() {};
+opentype.Path.prototype.fromSVG = function() {};
+
+/**
+ * @param  {number} x
+ * @param  {number} y
+ */
+opentype.Path.prototype.moveTo = function() {};
+
+/**
+ * @param  {number} x
+ * @param  {number} y
+ */
+opentype.Path.prototype.lineTo = function() {};
+
+/** @type {?} */
+opentype.Path.prototype.bezierCurveTo = function() {};
+
+/**
+ * Draws cubic curve
+ * @function
+ * bezierCurveTo
+ * @memberof opentype.Path.prototype
+ * @param  {number} x1 - x of control 1
+ * @param  {number} y1 - y of control 1
+ * @param  {number} x2 - x of control 2
+ * @param  {number} y2 - y of control 2
+ * @param  {number} x - x of path point
+ * @param  {number} y - y of path point
+ * @see curveTo
+ */
+opentype.Path.prototype.curveTo = function() {};
+
+/** @type {?} */
+opentype.Path.prototype.quadraticCurveTo = function() {};
+
+/**
+ * Draws quadratic curve
+ * @function
+ * quadTo
+ * @memberof opentype.Path.prototype
+ * @param  {number} x1 - x of control
+ * @param  {number} y1 - y of control
+ * @param  {number} x - x of path point
+ * @param  {number} y - y of path point
+ */
+opentype.Path.prototype.quadTo = function() {};
 
 /**
  * Add the given path or list of commands to the commands of this path.
  * @param  {Array} pathOrCommands - another opentype.Path, an opentype.BoundingBox, or an array of commands.
  */
-opentype.Path.prototype.extend = function(pathOrCommands) {};
+opentype.Path.prototype.extend = function() {};
 
 /**
  * Calculate the bounding box of the path.
@@ -369,283 +792,70 @@ opentype.Path.prototype.extend = function(pathOrCommands) {};
 opentype.Path.prototype.getBoundingBox = function() {};
 
 /**
+ * Draw the path to a 2D context.
  * @param {CanvasRenderingContext2D} ctx - A 2D drawing context.
  */
-opentype.Path.prototype.draw = function(ctx) {};
+opentype.Path.prototype.draw = function() {};
 
 /**
- * @param  {number} [decimalPlaces=2] - The amount of decimal places for floating-point values
+ * Convert the Path to a string of path data instructions
+ * See http://www.w3.org/TR/SVG/paths.html#PathData
+ * @param  {object|number} [options={decimalPlaces:2, optimize:true}] - Options object (or amount of decimal places for floating-point values for backwards compatibility)
  * @return {string}
  */
-opentype.Path.prototype.toPathData = function(decimalPlaces) {};
+opentype.Path.prototype.toPathData = function() {};
 
 /**
- * @param  {number} [decimalPlaces=2] - The amount of decimal places for floating-point values
+ * Convert the path to an SVG <path> element, as a string.
+ * @param  {object|number} [options={decimalPlaces:2, optimize:true}] - Options object (or amount of decimal places for floating-point values for backwards compatibility)
+ * @param  {string} - will be calculated automatically, but can be provided from Glyph's wrapper function
  * @return {string}
  */
-opentype.Path.prototype.toSVG = function(decimalPlaces) {};
+opentype.Path.prototype.toSVG = function() {};
 
 /**
  * Convert the path to a DOM element.
- * @param  {number} [decimalPlaces=2] - The amount of decimal places for floating-point values
+ * @param  {object|number} [options={decimalPlaces:2, optimize:true}] - Options object (or amount of decimal places for floating-point values for backwards compatibility)
+ * @param  {string} [pathData] - will be calculated automatically, but can be provided from Glyph's wrapper functions
  * @return {SVGPathElement}
  */
-opentype.Path.prototype.toDOMElement = function(decimalPlaces) {};
+opentype.Path.prototype.toDOMElement = function() {};
 
-/**
- * @constructor
- */
-opentype.Layout = function(font, tableName) {};
+/** @type {?} */
+opentype._parse.getByte = function() {};
 
-/**
- * Binary search an object by "tag" property
- * @param  {Array} arr
- * @param  {string} tag
- * @return {number}
- */
-opentype.Layout.prototype.searchTag = function(arr, tag) {};
+/** @type {?} */
+opentype._parse.getCard8 = function() {};
 
-/**
- * Binary search in a list of numbers
- * @param  {Array} arr
- * @param  {number} value
- * @return {number}
- */
-opentype.Layout.prototype.binSearch = function (arr, value) {};
+/** @type {?} */
+opentype._parse.getUShort = function() {};
 
-/**
- * Get or create the Layout table (GSUB, GPOS etc).
- * @param  {boolean} create - Whether to create a new one.
- * @return {Object} The GSUB or GPOS table.
- */
-opentype.Layout.prototype.getTable = function(create) {};
+/** @type {?} */
+opentype._parse.getCard16 = function() {};
 
-/**
- * Returns all scripts in the substitution table.
- * @instance
- * @return {Array}
- */
-opentype.Layout.prototype.getScriptNames = function() {};
+/** @type {?} */
+opentype._parse.getShort = function() {};
 
-/**
- * Returns all LangSysRecords in the given script.
- * @instance
- * @param {string} script - Use 'DFLT' for default script
- * @param {boolean} create - forces the creation of this script table if it doesn't exist.
- * @return {Array} Array on names
- */
-opentype.Layout.prototype.getScriptTable = function(script, create) {};
+/** @type {?} */
+opentype._parse.getUInt24 = function() {};
 
-/**
- * Returns a language system table
- * @instance
- * @param {string} script - Use 'DFLT' for default script
- * @param {string} language - Use 'dlft' for default language
- * @param {boolean} create - forces the creation of this langSysTable if it doesn't exist.
- * @return {Object} An object with tag and script properties.
- */
-opentype.Layout.prototype.getLangSysTable = function(script, language, create) {};
+/** @type {?} */
+opentype._parse.getULong = function() {};
 
-/**
- * Get a specific feature table.
- * @instance
- * @param {string} script - Use 'DFLT' for default script
- * @param {string} language - Use 'dlft' for default language
- * @param {string} feature - One of the codes listed at https://www.microsoft.com/typography/OTSPEC/featurelist.htm
- * @param {boolean} create - forces the creation of the feature table if it doesn't exist.
- * @return {Object}
- */
-opentype.Layout.prototype.getFeatureTable = function(script, language, feature, create) {};
+/** @type {?} */
+opentype._parse.getFixed = function() {};
 
-/**
- * Get the lookup tables of a given type for a script/language/feature.
- * @instance
- * @param {string} [script='DFLT']
- * @param {string} [language='dlft']
- * @param {string} feature - 4-letter feature code
- * @param {number} lookupType - 1 to 8
- * @param {boolean} create - forces the creation of the lookup table if it doesn't exist, with no subtables.
- * @return {Object[]}
- */
-opentype.Layout.prototype.getLookupTables = function(script, language, feature, lookupType, create) {};
+/** @type {?} */
+opentype._parse.getTag = function() {};
 
-/**
- * Returns the list of glyph indexes of a coverage table.
- * Format 1: the list is stored raw
- * Format 2: compact list as range records.
- * @instance
- * @param  {Object} coverageTable
- * @return {Array}
- */
-opentype.Layout.prototype.expandCoverage = function(coverageTable) {};
+/** @type {?} */
+opentype._parse.getOffset = function() {};
 
-/**
- * @extends opentype.Layout
- * @constructor
- * @param {opentype.Font}
- */
-opentype.Substitution = function(font) {};
+/** @type {?} */
+opentype._parse.getBytes = function() {};
 
-/**
- * Create a default GSUB table.
- * @return {Object} gsub - The GSUB table.
- */
-opentype.Substitution.prototype.createDefaultTable = function() {};
+/** @type {?} */
+opentype._parse.bytesToString = function() {};
 
-/**
- * List all single substitutions (lookup type 1) for a given script, language, and feature.
- * @param {string} script
- * @param {string} language
- * @param {string} feature - 4-character feature name ('aalt', 'salt', 'ss01'...)
- * @return {Array} substitutions - The list of substitutions.
- */
-opentype.Substitution.prototype.getSingle = function(feature, script, language) {};
-
-/**
- * List all alternates (lookup type 3) for a given script, language, and feature.
- * @param {string} feature - 4-character feature name ('aalt', 'salt'...)
- * @param {string} script
- * @param {string} language
- * @return {Array} alternates - The list of alternates
- */
-opentype.Substitution.prototype.getAlternates = function(feature, script, language) {};
-
-/**
- * List all ligatures (lookup type 4) for a given script, language, and feature.
- * The result is an array of ligature objects like { sub: [ids], by: id }
- * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
- * @param {string} script
- * @param {string} language
- * @return {Array} ligatures - The list of ligatures.
- */
-opentype.Substitution.prototype.getLigatures = function(feature, script, language) {};
-
-/**
- * Add or modify a single substitution (lookup type 1)
- * Format 2, more flexible, is always used.
- * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
- * @param {Object} substitution - { sub: id, delta: number } for format 1 or { sub: id, by: id } for format 2.
- * @param {string} [script='DFLT']
- * @param {string} [language='dflt']
- */
-opentype.Substitution.prototype.addSingle = function(feature, substitution, script, language) {};
-
-/**
- * Add or modify an alternate substitution (lookup type 1)
- * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
- * @param {Object} substitution - { sub: id, by: [ids] }
- * @param {string} [script='DFLT']
- * @param {string} [language='dflt']
- */
-opentype.Substitution.prototype.addAlternate = function(feature, substitution, script, language) {};
-
-/**
- * Add a ligature (lookup type 4)
- * Ligatures with more components must be stored ahead of those with fewer components in order to be found
- * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
- * @param {Object} ligature - { sub: [ids], by: id }
- * @param {string} [script='DFLT']
- * @param {string} [language='dflt']
- */
-opentype.Substitution.prototype.addLigature = function(feature, ligature, script, language) {};
-
-/**
- * List all feature data for a given script and language.
- * @param {string} feature - 4-letter feature name
- * @param {string} [script='DFLT']
- * @param {string} [language='dflt']
- * @return {[type]} [description]
- * @return {Array} substitutions - The list of substitutions.
- */
-opentype.Substitution.prototype.getFeature = function(feature, script, language) {};
-
-/**
- * Add a substitution to a feature for a given script and language.
- * @param {string} feature - 4-letter feature name
- * @param {Object} sub - the substitution to add (an Object like { sub: id or [ids], by: id or [ids] })
- * @param {string} [script='DFLT']
- * @param {string} [language='dflt']
- */
-opentype.Substitution.prototype.add = function(feature, sub, script, language) {};
-
-/**
- * @param {string} tableName
- * @param {Array} fields
- * @param {Object} options
- * @constructor
- */
-opentype.Table = function(tableName, fields, options) {};
-
-/**
- * Encodes the table and returns an array of bytes
- * @return {Array}
- */
-opentype.Table.prototype.encode = function() {};
-
-/**
- * Get the size of the table.
- * @return {number}
- */
-opentype.Table.prototype.sizeOf = function() {};
-
-/**
- * @type {string}
- */
-opentype.Table.prototype.tableName;
-
-/**
- * @type {Array}
- */
-opentype.Table.prototype.fields;
-
-/**
- * @extends {opentype.Table}
- * @param {opentype.Table} coverageTable
- * @constructor
- */
-opentype.Coverage = function(coverageTable) {};
-
-/**
- * @extends {opentype.Table}
- * @param {opentype.Table} scriptListTable
- * @constructor
- */
-opentype.ScriptList = function(scriptListTable) {};
-
-/**
- * @extends {opentype.Table}
- * @param {opentype.Table} featureListTable
- * @constructor
- */
-opentype.FeatureList = function(featureListTable) {};
-
-/**
- * @extends {opentype.Table}
- * @param {opentype.Table} lookupListTable
- * @param {Object} subtableMakers
- * @constructor
- */
-opentype.LookupList = function(lookupListTable, subtableMakers) {};
-
-/**
- * @constructor
- */
-opentype.BoundingBox = function() {};
-
-/**
- * @param  {string} url - The URL of the font to load.
- * @param  {Function} callback - The callback.
- */
-opentype.load = function(url, callback) {};
-
-/**
- * @param  {string} url - The URL of the font to load.
- * @return {opentype.Font}
- */
-opentype.loadSync = function(url) {};
-
-/**
- * @param  {ArrayBuffer}
- * @return {opentype.Font}
- */
-opentype.parse = function(buffer) {};
+/** @type {?} */
+opentype._parse.Parser = function() {};

--- a/externs/opentype.js
+++ b/externs/opentype.js
@@ -7,6 +7,96 @@
 var opentype = {};
 
 /**
+ * @typedef NamePlatform
+ * @type {{
+ *      fontFamily: Object<string,string>,
+ *      fontSubfamily: Object<string,string>,
+ *      fullName: Object<string,string>,
+ *      postScriptName: Object<string,string>,
+ *      designer: Object<string,string>,
+ *      designerURL: Object<string,string>,
+ *      manufacturer: Object<string,string>,
+ *      manufacturerURL: Object<string,string>,
+ *      license: Object<string,string>,
+ *      licenseURL: Object<string,string>,
+ *      version: Object<string,string>,
+ *      description: Object<string,string>,
+ *      copyright: Object<string,string>,
+ *      trademark: Object<string,string>
+ * }}
+ */
+var NamePlatform;
+
+/**
+ * @typedef FontOptions
+ * @type Object
+ * @property {Boolean} empty - whether to create a new empty font
+ * @property {string} familyName
+ * @property {string} styleName
+ * @property {string=} fullName
+ * @property {string=} postScriptName
+ * @property {string=} designer
+ * @property {string=} designerURL
+ * @property {string=} manufacturer
+ * @property {string=} manufacturerURL
+ * @property {string=} license
+ * @property {string=} licenseURL
+ * @property {string=} version
+ * @property {string=} description
+ * @property {string=} copyright
+ * @property {string=} trademark
+ * @property {Number} unitsPerEm
+ * @property {Number} ascender
+ * @property {Number} descender
+ * @property {Number} createdTimestamp
+ * @property {Number} weightClass
+ * @property {Number} italicAngle
+ * @property {string=} widthClass
+ * @property {string=} fsSelection
+ */
+var FontOptions;
+
+/**
+ * @typedef GlyphRenderOptions
+ * @type Object
+ * @property {string} [script] - script used to determine which features to apply. By default, 'DFLT' or 'latn' is used.
+ *                               See https://www.microsoft.com/typography/otspec/scripttags.htm
+ * @property {string} [language='dflt'] - language system used to determine which features to apply.
+ *                                        See https://www.microsoft.com/typography/developers/opentype/languagetags.aspx
+ * @property {boolean} [kerning=true] - whether to include kerning values
+ * @property {object} [features] - OpenType Layout feature tags. Used to enable or disable the features of the given script/language system.
+ *                                 See https://www.microsoft.com/typography/otspec/featuretags.htm
+ * @property {boolean} [hinting=false] - whether to apply font hinting to the outlines
+ * @property {integer} [usePalette=0] For COLR/CPAL fonts, the zero-based index of the color palette to use. (Use `Font.palettes.get()` to get the available palettes)
+ * @property {boolean} [drawLayers=true] For COLR/CPAL fonts, this can be turned to false in order to draw the fallback glyphs instead
+ * @property {boolean} [drawSVG=true] For SVG fonts, this can be turned to false in order to draw the fallback glyphs instead
+ */
+var GlyphRenderOptions;
+
+/**
+ * @typedef GlyphOptions
+ * @type Object
+ * @property {string} [name] - The glyph name
+ * @property {number} [unicode]
+ * @property {Array} [unicodes]
+ * @property {number} [xMin]
+ * @property {number} [yMin]
+ * @property {number} [xMax]
+ * @property {number} [yMax]
+ * @property {number} [advanceWidth]
+ * @property {number} [leftSideBearing]
+ */
+var GlyphOptions;
+
+/**
+ * @typedef {Object} SVGImage
+ * @prop {number} leftSideBearing
+ * @prop {number} baseline
+ * @prop {HTMLImageElement} image
+ */
+var SVGImage;
+
+/**
  * A Font represents a loaded OpenType font file.
  * It contains a set of glyphs and methods to draw text on a drawing context,
  * or to get a path representing the text.
@@ -47,12 +137,6 @@ opentype.Path = function() {};
 opentype.BoundingBox = function() {};
 
 /**
-     * Low-level parse utilities.
-     * @alias opentype._parse
-     */
-opentype._parse = function() {};
-
-/**
  * Parse the OpenType file data (as an ArrayBuffer) and return a Font object.
  * Throws an error if the font could not be parsed.
  * @param  {ArrayBuffer}
@@ -79,6 +163,30 @@ opentype.load = function() {};
  * @deprecated
  */
 opentype.loadSync = function() {};
+
+/**
+     * The minimum X coordinate of the bounding box.
+     * @type {number}
+     */
+opentype.BoundingBox.prototype.x1 = function() {};
+
+/**
+     * The minimum Y coordinate of the bounding box.
+     * @type {number}
+     */
+opentype.BoundingBox.prototype.y1 = function() {};
+
+/**
+     * The maximum X coordinate of the bounding box.
+     * @type {number}
+     */
+opentype.BoundingBox.prototype.x2 = function() {};
+
+/**
+     * The maximum Y coordinate of the bounding box.
+     * @type {number}
+     */
+opentype.BoundingBox.prototype.y2 = function() {};
 
 /**
  * Returns true if the bounding box is empty, that is, no points have been added to the box yet.
@@ -134,6 +242,109 @@ opentype.BoundingBox.prototype.addBezier = function() {};
  * @param {number} y - The ending Y coordinate.
  */
 opentype.BoundingBox.prototype.addQuad = function() {};
+
+/**
+     * Variable font variation data, available if the font has variable axes (gvar or cff2 tables).
+     * @type {VariationManager|undefined}
+     * @alias opentype.Font.prototype.variation
+     */
+opentype.Font.prototype.variation = function() {};
+
+/**
+         * Font name information in multiple languages and platforms.
+         * @type {{unicode: ?NamePlatform, macintosh: ?NamePlatform, windows: ?NamePlatform}}
+         */
+opentype.Font.prototype.names = function() {};
+
+/**
+         * Units per em (the font design grid size).
+         * @type {number}
+         */
+opentype.Font.prototype.unitsPerEm = function() {};
+
+/**
+         * The ascender value of the font.
+         * @type {number}
+         */
+opentype.Font.prototype.ascender = function() {};
+
+/**
+         * The descender value of the font (typically negative).
+         * @type {number}
+         */
+opentype.Font.prototype.descender = function() {};
+
+/**
+         * Unix timestamp when the font was created.
+         * @type {number}
+         */
+opentype.Font.prototype.createdTimestamp = function() {};
+
+/**
+         * The italic angle of the font in degrees.
+         * @type {number}
+         */
+opentype.Font.prototype.italicAngle = function() {};
+
+/**
+         * The weight class of the font (100-900).
+         * @type {number}
+         */
+opentype.Font.prototype.weightClass = function() {};
+
+/**
+         * Font table objects containing raw table data.
+         * @type {Object}
+         */
+opentype.Font.prototype.tables = function() {};
+
+/**
+     * Indicates if the font is supported. Deprecated - errors are thrown during parsing if font is unsupported.
+     * @type {boolean}
+     */
+opentype.Font.prototype.supported = function() {};
+
+/**
+     * The set of glyphs in this font.
+     * @type {glyphset.GlyphSet}
+     */
+opentype.Font.prototype.glyphs = function() {};
+
+/**
+     * Character encoding table for the font.
+     * @type {Object}
+     */
+opentype.Font.prototype.encoding = function() {};
+
+/**
+     * Glyph positioning information for OpenType layout features.
+     * @type {Object}
+     */
+opentype.Font.prototype.position = function() {};
+
+/**
+     * Glyph substitution information for OpenType layout features.
+     * @type {Object}
+     */
+opentype.Font.prototype.substitution = function() {};
+
+/**
+     * Color palette manager for COLR/CPAL color fonts.
+     * @type {Object}
+     */
+opentype.Font.prototype.palettes = function() {};
+
+/**
+     * Layer manager for COLR layered color fonts.
+     * @type {Object}
+     */
+opentype.Font.prototype.layers = function() {};
+
+/**
+     * SVG image manager for SVG table color fonts.
+     * @type {Object}
+     */
+opentype.Font.prototype.svgImages = function() {};
 
 /**
  * Check if the font has a glyph for the given character.
@@ -395,7 +606,7 @@ opentype.Glyph.prototype.getLayers = function() {};
 
 /**
  * @param {opentype.Font} font
- * @returns {import('./svgimages.mjs').SVGImage | undefined}
+ * @returns {SVGImage | undefined}
  */
 opentype.Glyph.prototype.getSvgImage = function() {};
 
@@ -482,367 +693,32 @@ opentype.Glyph.prototype.toSVG = function() {};
 opentype.Glyph.prototype.toDOMElement = function() {};
 
 /**
- * Parse an unsigned 8-bit integer.
- * @return {number}
- */
-opentype._parse.prototype.parseByte = function() {};
+     * The list of drawing commands for the path.
+     * @type {Array<Object>}
+     * @alias opentype.Path.prototype.commands
+     */
+opentype.Path.prototype.commands = function() {};
 
 /**
- * Parse a signed 8-bit integer.
- * @return {number}
- */
-opentype._parse.prototype.parseChar = function() {};
+     * Fill color for the path. If null, the path is not filled.
+     * @type {string|null}
+     * @alias opentype.Path.prototype.fill
+     */
+opentype.Path.prototype.fill = function() {};
 
 /**
- * Parse an unsigned 8-bit integer.
- * @return {number}
- */
-opentype._parse.prototype.parseCard8 = function() {};
+     * Stroke color for the path. If null, the path is not stroked.
+     * @type {string|null}
+     * @alias opentype.Path.prototype.stroke
+     */
+opentype.Path.prototype.stroke = function() {};
 
 /**
- * Parse an unsigned 16-bit integer.
- * @return {number}
- */
-opentype._parse.prototype.parseUShort = function() {};
-
-/**
- * Parse an unsigned 16-bit integer.
- * @return {number}
- */
-opentype._parse.prototype.parseCard16 = function() {};
-
-/**
- * Parse a string identifier.
- * @return {number}
- */
-opentype._parse.prototype.parseSID = function() {};
-
-/**
- * Parse an offset16 value.
- * @return {number}
- */
-opentype._parse.prototype.parseOffset16 = function() {};
-
-/**
- * Parse a signed 16-bit integer.
- * @return {number}
- */
-opentype._parse.prototype.parseShort = function() {};
-
-/**
- * Parse a 2.14 fixed point number.
- * @return {number}
- */
-opentype._parse.prototype.parseF2Dot14 = function() {};
-
-/**
- * Parse a 24-bit unsigned integer.
- * @return {number}
- */
-opentype._parse.prototype.parseUInt24 = function() {};
-
-/**
- * Parse a 32-bit unsigned integer.
- * @return {number}
- */
-opentype._parse.prototype.parseULong = function() {};
-
-/**
- * Parse a 32-bit signed integer.
- * @return {number}
- */
-opentype._parse.prototype.parseLong = function() {};
-
-/**
- * Parse a 32-bit unsigned integer offset.
- * @return {number}
- */
-opentype._parse.prototype.parseOffset32 = function() {};
-
-/**
- * Parse a 16.16 fixed point number.
- * @return {number}
- */
-opentype._parse.prototype.parseFixed = function() {};
-
-/**
- * Parse a string of the given byte length.
- * @param {number} length
- * @return {string}
- */
-opentype._parse.prototype.parseString = function() {};
-
-/**
- * Parse a 4-character tag.
- * @return {string}
- */
-opentype._parse.prototype.parseTag = function() {};
-
-/**
- * Parse a LONGDATETIME (Mac epoch) and convert to Unix seconds.
- * @return {number}
- */
-opentype._parse.prototype.parseLongDateTime = function() {};
-
-/**
- * Parse a fixed-point version number.
- * @param {number=} minorBase
- * @return {number}
- */
-opentype._parse.prototype.parseVersion = function() {};
-
-/**
- * Skip a number of items of the given type.
- * @param {string} type
- * @param {number=} amount
- * @return {undefined}
- */
-opentype._parse.prototype.skip = function() {};
-
-/**
- * Parse a list of 32-bit unsigned integers.
- * @param {number=} count
- * @return {number[]}
- */
-opentype._parse.prototype.parseULongList = function() {};
-
-/**
- * Parse a list of 16-bit unsigned integers.
- * @param {number=} count
- * @return {number[]}
- */
-opentype._parse.prototype.parseOffset16List = function() {};
-
-/**
- * Parse a list of 16-bit unsigned integers.
- * @param {number=} count
- * @return {number[]}
- */
-opentype._parse.prototype.parseUShortList = function() {};
-
-/**
- * Parse a list of 16-bit signed integers.
- * @param {number} count
- * @return {number[]}
- */
-opentype._parse.prototype.parseShortList = function() {};
-
-/**
- * Parse a list of bytes.
- * @param {number} count
- * @return {number[]}
- */
-opentype._parse.prototype.parseByteList = function() {};
-
-/**
- * Parse a list of items.
- * Record count is optional, if omitted it is read from the stream.
- * itemCallback is one of the Parser methods.
- * @template T
- * @param {number|function()} [count]
- * @param {function():T} [itemCallback]
- * @return {Array<T>}
- */
-opentype._parse.prototype.parseList = function() {};
-
-/**
- * Parse a list of items using a 32-bit count.
- * @template T
- * @param {number|function()} [count]
- * @param {function():T} [itemCallback]
- * @return {Array<T>}
- */
-opentype._parse.prototype.parseList32 = function() {};
-
-/**
- * Parse a list of records.
- * Record count is optional, if omitted it is read from the stream.
- * Example of recordDescription: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
- * @param {number|Object} [count]
- * @param {Object} [recordDescription]
- * @return {Array<Object>}
- */
-opentype._parse.prototype.parseRecordList = function() {};
-
-/**
- * Parse a list of records using a 32-bit count.
- * @param {number|Object} [count]
- * @param {Object} [recordDescription]
- * @return {Array<Object>}
- */
-opentype._parse.prototype.parseRecordList32 = function() {};
-
-/**
- * Parse N tuples of F2.14 values.
- * @param {number} tupleCount
- * @param {number} axisCount
- * @return {Array<Array<number>>}
- */
-opentype._parse.prototype.parseTupleRecords = function() {};
-
-/**
- * Parse a data structure into an object.
- * Example of description: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
- * @param {Object|function()} description
- * @return {Object}
- */
-opentype._parse.prototype.parseStruct = function() {};
-
-/**
- * Parse a GPOS valueRecord
- * https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#value-record
- * valueFormat is optional, if omitted it is read from the stream.
- * @param {number=} valueFormat
- * @return {Object|undefined}
- */
-opentype._parse.prototype.parseValueRecord = function() {};
-
-/**
- * Parse a list of GPOS valueRecords
- * https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#value-record
- * valueFormat and valueCount are read from the stream.
- */
-opentype._parse.prototype.parseValueRecordList = function() {};
-
-/**
- * Parse a pointer to another offset-based structure.
- * @param {Object|function()} description
- * @return {Object|undefined}
- */
-opentype._parse.prototype.parsePointer = function() {};
-
-/**
- * Parse a 32-bit pointer to another offset-based structure.
- * @param {Object|function()} description
- * @return {Object|undefined}
- */
-opentype._parse.prototype.parsePointer32 = function() {};
-
-/**
- * Parse a list of lists of values from the stream.
- * If no itemCallback is provided, it parses a list of UShort lists.
- * @template T
- * @param {function():T} [itemCallback]
- * @return {Array<T|undefined>}
- */
-opentype._parse.prototype.parseListOfLists = function() {};
-
-/**
- * Parse a coverage table in a GSUB, GPOS or GDEF table.
- * @return {Object}
- */
-opentype._parse.prototype.parseCoverage = function() {};
-
-/**
- * Parse a class definition table in a GSUB, GPOS or GDEF table.
- * @return {Object}
- */
-opentype._parse.prototype.parseClassDef = function() {};
-
-/**
- * Parse a ScriptList and return an array of `ScriptRecord`.
- * @return {ScriptRecord[]}
- */
-opentype._parse.prototype.parseScriptList = function() {};
-
-/**
- * Parse a FeatureList and return an array of `FeatureRecord`.
- * @return {FeatureRecord[]}
- */
-opentype._parse.prototype.parseFeatureList = function() {};
-
-/**
- * Parse a LookupList using provided parsers and return an array of `Lookup` objects.
- * @param {Object} lookupTableParsers - map of lookupType to parser function
- * @return {Lookup[]}
- */
-opentype._parse.prototype.parseLookupList = function() {};
-
-/**
- * Parse a FeatureVariationsList.
- * @return {Object[]}
- */
-opentype._parse.prototype.parseFeatureVariationsList = function() {};
-
-/**
- * Parse a VariationStore structure.
- * @return {VariationStore}
- */
-opentype._parse.prototype.parseVariationStore = function() {};
-
-/**
- * Parse an ItemVariationStore.
- * @return {ItemVariationStore}
- */
-opentype._parse.prototype.parseItemVariationStore = function() {};
-
-/**
- * Parse a VariationRegionList.
- * @return {Array<Object>}
- */
-opentype._parse.prototype.parseVariationRegionList = function() {};
-
-/**
- * Parse an ItemVariationSubtable.
- * @return {ItemVariationSubtable}
- */
-opentype._parse.prototype.parseItemVariationSubtable = function() {};
-
-/**
- * Parse a DeltaSetIndexMap.
- * @return {DeltaSetIndexMap}
- */
-opentype._parse.prototype.parseDeltaSetIndexMap = function() {};
-
-/**
- * Parse delta sets for item variation subtables.
- * @param {number} itemCount
- * @param {number} wordDeltaCount
- * @param {number} regionIndexCount
- * @return {number[][]}
- */
-opentype._parse.prototype.parseDeltaSets = function() {};
-
-/**
- * Parse a TupleVariationStoreList and return a glyph-indexed map of variation stores.
- * @param {number} axisCount
- * @param {string} flavor
- * @param {Map<number, Object>|Array} glyphs
- * @return {Object.<number, (Object|undefined)>}
- */
-opentype._parse.prototype.parseTupleVariationStoreList = function() {};
-
-/**
- * Parse a TupleVariationStore at the given offset.
- * @param {number} tableOffset
- * @param {number} axisCount
- * @param {string} flavor
- * @param {Map<number, Object>|Array} glyphs
- * @param {number} glyphIndex
- * @return {Object}
- */
-opentype._parse.prototype.parseTupleVariationStore = function() {};
-
-/**
- * Parse a TupleVariationHeader.
- * @param {number} axisCount
- * @param {string} flavor
- * @return {TupleVariationHeader}
- */
-opentype._parse.prototype.parseTupleVariationHeader = function() {};
-
-/**
- * Parse packed point numbers and return an array of point indices.
- * @return {number[]}
- */
-opentype._parse.prototype.parsePackedPointNumbers = function() {};
-
-/**
- * Parse packed delta values and return an array of deltas.
- * @param {number} expectedCount
- * @return {number[]}
- */
-opentype._parse.prototype.parsePackedDeltas = function() {};
+     * Stroke width for the path outline.
+     * @type {number}
+     * @alias opentype.Path.prototype.strokeWidth
+     */
+opentype.Path.prototype.strokeWidth = function() {};
 
 /**
  * Draws cubic curve
@@ -861,8 +737,7 @@ curveTo = function() {};
 
 /**
  * Draws cubic curve
- * @function
- * bezierCurveTo
+ * @function curveTo
  * @memberof opentype.Path.prototype
  * @alias opentype.Path.prototype.bezierCurveTo
  * @param  {number} x1 - x of control 1
@@ -871,14 +746,13 @@ curveTo = function() {};
  * @param  {number} y2 - y of control 2
  * @param  {number} x - x of path point
  * @param  {number} y - y of path point
- * @see curveTo
+ * @see bezierCurveTo
  */
 opentype.Path.prototype.bezierCurveTo = function() {};
 
 /**
  * Draws quadratic curve
- * @function
- * quadraticCurveTo
+ * @function quadTo
  * @memberof opentype.Path.prototype
  * @alias opentype.Path.prototype.quadraticCurveTo
  * @param  {number} x1 - x of control
@@ -887,19 +761,6 @@ opentype.Path.prototype.bezierCurveTo = function() {};
  * @param  {number} y - y of path point
  */
 opentype.Path.prototype.quadraticCurveTo = function() {};
-
-/**
- * Draws quadratic curve
- * @function
- * quadTo
- * @memberof opentype.Path.prototype
- * @param  {number} x1 - x of control
- * @param  {number} y1 - y of control
- * @param  {number} x - x of path point
- * @param  {number} y - y of path point
- */
-opentype.Path.prototype.
-quadTo = function() {};
 
 /**
  * Closes the path
@@ -936,8 +797,7 @@ opentype.Path.prototype.lineTo = function() {};
 
 /**
  * Draws cubic curve
- * @function
- * bezierCurveTo
+ * @function curveTo
  * @memberof opentype.Path.prototype
  * @alias opentype.Path.prototype.bezierCurveTo
  * @param  {number} x1 - x of control 1
@@ -946,15 +806,15 @@ opentype.Path.prototype.lineTo = function() {};
  * @param  {number} y2 - y of control 2
  * @param  {number} x - x of path point
  * @param  {number} y - y of path point
- * @see curveTo
+ * @see bezierCurveTo
  */
 opentype.Path.prototype.curveTo = function() {};
 
 /**
  * Draws quadratic curve
- * @function
- * quadTo
+ * @function quadTo
  * @memberof opentype.Path.prototype
+ * @alias opentype.Path.prototype.quadraticCurveTo
  * @param  {number} x1 - x of control
  * @param  {number} y1 - y of control
  * @param  {number} x - x of path point
@@ -1003,121 +863,3 @@ opentype.Path.prototype.toSVG = function() {};
  * @return {SVGPathElement}
  */
 opentype.Path.prototype.toDOMElement = function() {};
-
-/**
-     * Parse an unsigned 8-bit integer.
-     * @alias opentype._parse.getByte
-     * @param {DataView} data
-     * @param {number} offset
-     * @return {number}
-     */
-opentype._parse.getByte = function() {};
-
-/**
-     * Parse an unsigned 8-bit integer.
-     * @alias opentype._parse.getCard8
-     * @param {DataView} data
-     * @param {number} offset
-     * @return {number}
-     */
-opentype._parse.getCard8 = function() {};
-
-/**
-     * Parse an unsigned 16-bit integer.
-     * @alias opentype._parse.getUShort
-     * @param {DataView} data
-     * @param {number} offset
-     * @return {number}
-     */
-opentype._parse.getUShort = function() {};
-
-/**
-     * Parse an unsigned 16-bit integer.
-     * @alias opentype._parse.getCard16
-     * @param {DataView} data
-     * @param {number} offset
-     * @return {number}
-     */
-opentype._parse.getCard16 = function() {};
-
-/**
-     * Parse a signed 16-bit integer.
-     * @alias opentype._parse.getShort
-     * @param {DataView} data
-     * @param {number} offset
-     * @return {number}
-     */
-opentype._parse.getShort = function() {};
-
-/**
-     * Parse a 24-bit unsigned integer.
-     * @alias opentype._parse.getUInt24
-     * @param {DataView} data
-     * @param {number} offset
-     * @return {number}
-     */
-opentype._parse.getUInt24 = function() {};
-
-/**
-     * Parse a 32-bit unsigned integer.
-     * @alias opentype._parse.getULong
-     * @param {DataView} data
-     * @param {number} offset
-     * @return {number}
-     */
-opentype._parse.getULong = function() {};
-
-/**
-     * Parse a 16.16 fixed point number.
-     * @alias opentype._parse.getFixed
-     * @param {DataView} data
-     * @param {number} offset
-     * @return {number}
-     */
-opentype._parse.getFixed = function() {};
-
-/**
-     * Parse a 4-character tag.
-     * @alias opentype._parse.getTag
-     * @param {DataView} data
-     * @param {number} offset
-     * @return {string}
-     */
-opentype._parse.getTag = function() {};
-
-/**
-     * Parse an offset from the DataView.
-     * @alias opentype._parse.getOffset
-     * @param {DataView} data
-     * @param {number} offset
-     * @param {number} offSize
-     * @return {number}
-     */
-opentype._parse.getOffset = function() {};
-
-/**
-     * Retrieve a number of bytes from start offset to the end offset.
-     * @alias opentype._parse.getBytes
-     * @param {DataView} dataView
-     * @param {number} startOffset
-     * @param {number} endOffset
-     * @return {number[]}
-     */
-opentype._parse.getBytes = function() {};
-
-/**
-     * Convert bytes to a string.
-     * @alias opentype._parse.bytesToString
-     * @param {number[]} bytes
-     * @return {string}
-     */
-opentype._parse.bytesToString = function() {};
-
-/**
-     * Parser constructor.
-     * @alias opentype._parse.Parser
-     * @constructor
-     * @param {DataView} data
-     * @param {number=} offset
-     */
-opentype._parse.Parser = function() {};

--- a/externs/opentype.js
+++ b/externs/opentype.js
@@ -46,7 +46,10 @@ opentype.Path = function() {};
  */
 opentype.BoundingBox = function() {};
 
-/** @type {?} */
+/**
+     * Low-level parse utilities.
+     * @alias opentype._parse
+     */
 opentype._parse = function() {};
 
 /**
@@ -478,108 +481,219 @@ opentype.Glyph.prototype.toSVG = function() {};
  */
 opentype.Glyph.prototype.toDOMElement = function() {};
 
-/** @type {?} */
+/**
+ * Parse an unsigned 8-bit integer.
+ * @return {number}
+ */
 opentype._parse.prototype.parseByte = function() {};
 
-/** @type {?} */
+/**
+ * Parse a signed 8-bit integer.
+ * @return {number}
+ */
 opentype._parse.prototype.parseChar = function() {};
 
-/** @type {?} */
+/**
+ * Parse an unsigned 8-bit integer.
+ * @return {number}
+ */
 opentype._parse.prototype.parseCard8 = function() {};
 
-/** @type {?} */
+/**
+ * Parse an unsigned 16-bit integer.
+ * @return {number}
+ */
 opentype._parse.prototype.parseUShort = function() {};
 
-/** @type {?} */
+/**
+ * Parse an unsigned 16-bit integer.
+ * @return {number}
+ */
 opentype._parse.prototype.parseCard16 = function() {};
 
-/** @type {?} */
+/**
+ * Parse a string identifier.
+ * @return {number}
+ */
 opentype._parse.prototype.parseSID = function() {};
 
-/** @type {?} */
+/**
+ * Parse an offset16 value.
+ * @return {number}
+ */
 opentype._parse.prototype.parseOffset16 = function() {};
 
-/** @type {?} */
+/**
+ * Parse a signed 16-bit integer.
+ * @return {number}
+ */
 opentype._parse.prototype.parseShort = function() {};
 
-/** @type {?} */
+/**
+ * Parse a 2.14 fixed point number.
+ * @return {number}
+ */
 opentype._parse.prototype.parseF2Dot14 = function() {};
 
-/** @type {?} */
+/**
+ * Parse a 24-bit unsigned integer.
+ * @return {number}
+ */
 opentype._parse.prototype.parseUInt24 = function() {};
 
-/** @type {?} */
+/**
+ * Parse a 32-bit unsigned integer.
+ * @return {number}
+ */
 opentype._parse.prototype.parseULong = function() {};
 
-/** @type {?} */
+/**
+ * Parse a 32-bit signed integer.
+ * @return {number}
+ */
 opentype._parse.prototype.parseLong = function() {};
 
-/** @type {?} */
+/**
+ * Parse a 32-bit unsigned integer offset.
+ * @return {number}
+ */
 opentype._parse.prototype.parseOffset32 = function() {};
 
-/** @type {?} */
+/**
+ * Parse a 16.16 fixed point number.
+ * @return {number}
+ */
 opentype._parse.prototype.parseFixed = function() {};
 
-/** @type {?} */
+/**
+ * Parse a string of the given byte length.
+ * @param {number} length
+ * @return {string}
+ */
 opentype._parse.prototype.parseString = function() {};
 
-/** @type {?} */
+/**
+ * Parse a 4-character tag.
+ * @return {string}
+ */
 opentype._parse.prototype.parseTag = function() {};
 
-/** @type {?} */
+/**
+ * Parse a LONGDATETIME (Mac epoch) and convert to Unix seconds.
+ * @return {number}
+ */
 opentype._parse.prototype.parseLongDateTime = function() {};
 
-/** @type {?} */
+/**
+ * Parse a fixed-point version number.
+ * @param {number=} minorBase
+ * @return {number}
+ */
 opentype._parse.prototype.parseVersion = function() {};
 
-/** @type {?} */
+/**
+ * Skip a number of items of the given type.
+ * @param {string} type
+ * @param {number=} amount
+ * @return {undefined}
+ */
 opentype._parse.prototype.skip = function() {};
 
-/** @type {?} */
+/**
+ * Parse a list of 32-bit unsigned integers.
+ * @param {number=} count
+ * @return {number[]}
+ */
 opentype._parse.prototype.parseULongList = function() {};
 
-/** @type {?} */
-opentype._parse.prototype.parseUShortList = function() {};
-
-/** @type {?} */
+/**
+ * Parse a list of 16-bit unsigned integers.
+ * @param {number=} count
+ * @return {number[]}
+ */
 opentype._parse.prototype.parseOffset16List = function() {};
 
-/** @type {?} */
+/**
+ * Parse a list of 16-bit unsigned integers.
+ * @param {number=} count
+ * @return {number[]}
+ */
+opentype._parse.prototype.parseUShortList = function() {};
+
+/**
+ * Parse a list of 16-bit signed integers.
+ * @param {number} count
+ * @return {number[]}
+ */
 opentype._parse.prototype.parseShortList = function() {};
 
-/** @type {?} */
+/**
+ * Parse a list of bytes.
+ * @param {number} count
+ * @return {number[]}
+ */
 opentype._parse.prototype.parseByteList = function() {};
 
 /**
  * Parse a list of items.
  * Record count is optional, if omitted it is read from the stream.
  * itemCallback is one of the Parser methods.
+ * @template T
+ * @param {number|function()} [count]
+ * @param {function():T} [itemCallback]
+ * @return {Array<T>}
  */
 opentype._parse.prototype.parseList = function() {};
 
-/** @type {?} */
+/**
+ * Parse a list of items using a 32-bit count.
+ * @template T
+ * @param {number|function()} [count]
+ * @param {function():T} [itemCallback]
+ * @return {Array<T>}
+ */
 opentype._parse.prototype.parseList32 = function() {};
 
 /**
  * Parse a list of records.
  * Record count is optional, if omitted it is read from the stream.
  * Example of recordDescription: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
+ * @param {number|Object} [count]
+ * @param {Object} [recordDescription]
+ * @return {Array<Object>}
  */
 opentype._parse.prototype.parseRecordList = function() {};
 
-/** @type {?} */
+/**
+ * Parse a list of records using a 32-bit count.
+ * @param {number|Object} [count]
+ * @param {Object} [recordDescription]
+ * @return {Array<Object>}
+ */
 opentype._parse.prototype.parseRecordList32 = function() {};
 
-/** @type {?} */
+/**
+ * Parse N tuples of F2.14 values.
+ * @param {number} tupleCount
+ * @param {number} axisCount
+ * @return {Array<Array<number>>}
+ */
 opentype._parse.prototype.parseTupleRecords = function() {};
 
-/** @type {?} */
+/**
+ * Parse a data structure into an object.
+ * Example of description: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
+ * @param {Object|function()} description
+ * @return {Object}
+ */
 opentype._parse.prototype.parseStruct = function() {};
 
 /**
  * Parse a GPOS valueRecord
  * https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#value-record
  * valueFormat is optional, if omitted it is read from the stream.
+ * @param {number=} valueFormat
+ * @return {Object|undefined}
  */
 opentype._parse.prototype.parseValueRecord = function() {};
 
@@ -590,70 +704,144 @@ opentype._parse.prototype.parseValueRecord = function() {};
  */
 opentype._parse.prototype.parseValueRecordList = function() {};
 
-/** @type {?} */
+/**
+ * Parse a pointer to another offset-based structure.
+ * @param {Object|function()} description
+ * @return {Object|undefined}
+ */
 opentype._parse.prototype.parsePointer = function() {};
 
-/** @type {?} */
+/**
+ * Parse a 32-bit pointer to another offset-based structure.
+ * @param {Object|function()} description
+ * @return {Object|undefined}
+ */
 opentype._parse.prototype.parsePointer32 = function() {};
 
 /**
- * Parse a list of offsets to lists of 16-bit integers,
- * or a list of offsets to lists of offsets to any kind of items.
- * If itemCallback is not provided, a list of list of UShort is assumed.
- * If provided, itemCallback is called on each item and must parse the item.
- * See examples in tables/gsub.mjs
+ * Parse a list of lists of values from the stream.
+ * If no itemCallback is provided, it parses a list of UShort lists.
+ * @template T
+ * @param {function():T} [itemCallback]
+ * @return {Array<T|undefined>}
  */
 opentype._parse.prototype.parseListOfLists = function() {};
 
-/** @type {?} */
+/**
+ * Parse a coverage table in a GSUB, GPOS or GDEF table.
+ * @return {Object}
+ */
 opentype._parse.prototype.parseCoverage = function() {};
 
-/** @type {?} */
+/**
+ * Parse a class definition table in a GSUB, GPOS or GDEF table.
+ * @return {Object}
+ */
 opentype._parse.prototype.parseClassDef = function() {};
 
-/** @type {?} */
+/**
+ * Parse a ScriptList and return an array of `ScriptRecord`.
+ * @return {ScriptRecord[]}
+ */
 opentype._parse.prototype.parseScriptList = function() {};
 
-/** @type {?} */
+/**
+ * Parse a FeatureList and return an array of `FeatureRecord`.
+ * @return {FeatureRecord[]}
+ */
 opentype._parse.prototype.parseFeatureList = function() {};
 
-/** @type {?} */
+/**
+ * Parse a LookupList using provided parsers and return an array of `Lookup` objects.
+ * @param {Object} lookupTableParsers - map of lookupType to parser function
+ * @return {Lookup[]}
+ */
 opentype._parse.prototype.parseLookupList = function() {};
 
-/** @type {?} */
+/**
+ * Parse a FeatureVariationsList.
+ * @return {Object[]}
+ */
 opentype._parse.prototype.parseFeatureVariationsList = function() {};
 
-/** @type {?} */
+/**
+ * Parse a VariationStore structure.
+ * @return {VariationStore}
+ */
 opentype._parse.prototype.parseVariationStore = function() {};
 
-/** @type {?} */
+/**
+ * Parse an ItemVariationStore.
+ * @return {ItemVariationStore}
+ */
 opentype._parse.prototype.parseItemVariationStore = function() {};
 
-/** @type {?} */
+/**
+ * Parse a VariationRegionList.
+ * @return {Array<Object>}
+ */
 opentype._parse.prototype.parseVariationRegionList = function() {};
 
-/** @type {?} */
+/**
+ * Parse an ItemVariationSubtable.
+ * @return {ItemVariationSubtable}
+ */
 opentype._parse.prototype.parseItemVariationSubtable = function() {};
 
-/** @type {?} */
+/**
+ * Parse a DeltaSetIndexMap.
+ * @return {DeltaSetIndexMap}
+ */
 opentype._parse.prototype.parseDeltaSetIndexMap = function() {};
 
-/** @type {?} */
+/**
+ * Parse delta sets for item variation subtables.
+ * @param {number} itemCount
+ * @param {number} wordDeltaCount
+ * @param {number} regionIndexCount
+ * @return {number[][]}
+ */
 opentype._parse.prototype.parseDeltaSets = function() {};
 
-/** @type {?} */
+/**
+ * Parse a TupleVariationStoreList and return a glyph-indexed map of variation stores.
+ * @param {number} axisCount
+ * @param {string} flavor
+ * @param {Map<number, Object>|Array} glyphs
+ * @return {Object.<number, (Object|undefined)>}
+ */
 opentype._parse.prototype.parseTupleVariationStoreList = function() {};
 
-/** @type {?} */
+/**
+ * Parse a TupleVariationStore at the given offset.
+ * @param {number} tableOffset
+ * @param {number} axisCount
+ * @param {string} flavor
+ * @param {Map<number, Object>|Array} glyphs
+ * @param {number} glyphIndex
+ * @return {Object}
+ */
 opentype._parse.prototype.parseTupleVariationStore = function() {};
 
-/** @type {?} */
+/**
+ * Parse a TupleVariationHeader.
+ * @param {number} axisCount
+ * @param {string} flavor
+ * @return {TupleVariationHeader}
+ */
 opentype._parse.prototype.parseTupleVariationHeader = function() {};
 
-/** @type {?} */
+/**
+ * Parse packed point numbers and return an array of point indices.
+ * @return {number[]}
+ */
 opentype._parse.prototype.parsePackedPointNumbers = function() {};
 
-/** @type {?} */
+/**
+ * Parse packed delta values and return an array of deltas.
+ * @param {number} expectedCount
+ * @return {number[]}
+ */
 opentype._parse.prototype.parsePackedDeltas = function() {};
 
 /**
@@ -676,6 +864,7 @@ curveTo = function() {};
  * @function
  * bezierCurveTo
  * @memberof opentype.Path.prototype
+ * @alias opentype.Path.prototype.bezierCurveTo
  * @param  {number} x1 - x of control 1
  * @param  {number} y1 - y of control 1
  * @param  {number} x2 - x of control 2
@@ -684,21 +873,20 @@ curveTo = function() {};
  * @param  {number} y - y of path point
  * @see curveTo
  */
-opentype.Path.prototype.
-bezierCurveTo = function() {};
+opentype.Path.prototype.bezierCurveTo = function() {};
 
 /**
  * Draws quadratic curve
  * @function
  * quadraticCurveTo
  * @memberof opentype.Path.prototype
+ * @alias opentype.Path.prototype.quadraticCurveTo
  * @param  {number} x1 - x of control
  * @param  {number} y1 - y of control
  * @param  {number} x - x of path point
  * @param  {number} y - y of path point
  */
-opentype.Path.prototype.
-quadraticCurveTo = function() {};
+opentype.Path.prototype.quadraticCurveTo = function() {};
 
 /**
  * Draws quadratic curve
@@ -746,14 +934,12 @@ opentype.Path.prototype.moveTo = function() {};
  */
 opentype.Path.prototype.lineTo = function() {};
 
-/** @type {?} */
-opentype.Path.prototype.bezierCurveTo = function() {};
-
 /**
  * Draws cubic curve
  * @function
  * bezierCurveTo
  * @memberof opentype.Path.prototype
+ * @alias opentype.Path.prototype.bezierCurveTo
  * @param  {number} x1 - x of control 1
  * @param  {number} y1 - y of control 1
  * @param  {number} x2 - x of control 2
@@ -763,9 +949,6 @@ opentype.Path.prototype.bezierCurveTo = function() {};
  * @see curveTo
  */
 opentype.Path.prototype.curveTo = function() {};
-
-/** @type {?} */
-opentype.Path.prototype.quadraticCurveTo = function() {};
 
 /**
  * Draws quadratic curve
@@ -821,41 +1004,120 @@ opentype.Path.prototype.toSVG = function() {};
  */
 opentype.Path.prototype.toDOMElement = function() {};
 
-/** @type {?} */
+/**
+     * Parse an unsigned 8-bit integer.
+     * @alias opentype._parse.getByte
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
 opentype._parse.getByte = function() {};
 
-/** @type {?} */
+/**
+     * Parse an unsigned 8-bit integer.
+     * @alias opentype._parse.getCard8
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
 opentype._parse.getCard8 = function() {};
 
-/** @type {?} */
+/**
+     * Parse an unsigned 16-bit integer.
+     * @alias opentype._parse.getUShort
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
 opentype._parse.getUShort = function() {};
 
-/** @type {?} */
+/**
+     * Parse an unsigned 16-bit integer.
+     * @alias opentype._parse.getCard16
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
 opentype._parse.getCard16 = function() {};
 
-/** @type {?} */
+/**
+     * Parse a signed 16-bit integer.
+     * @alias opentype._parse.getShort
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
 opentype._parse.getShort = function() {};
 
-/** @type {?} */
+/**
+     * Parse a 24-bit unsigned integer.
+     * @alias opentype._parse.getUInt24
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
 opentype._parse.getUInt24 = function() {};
 
-/** @type {?} */
+/**
+     * Parse a 32-bit unsigned integer.
+     * @alias opentype._parse.getULong
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
 opentype._parse.getULong = function() {};
 
-/** @type {?} */
+/**
+     * Parse a 16.16 fixed point number.
+     * @alias opentype._parse.getFixed
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
 opentype._parse.getFixed = function() {};
 
-/** @type {?} */
+/**
+     * Parse a 4-character tag.
+     * @alias opentype._parse.getTag
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {string}
+     */
 opentype._parse.getTag = function() {};
 
-/** @type {?} */
+/**
+     * Parse an offset from the DataView.
+     * @alias opentype._parse.getOffset
+     * @param {DataView} data
+     * @param {number} offset
+     * @param {number} offSize
+     * @return {number}
+     */
 opentype._parse.getOffset = function() {};
 
-/** @type {?} */
+/**
+     * Retrieve a number of bytes from start offset to the end offset.
+     * @alias opentype._parse.getBytes
+     * @param {DataView} dataView
+     * @param {number} startOffset
+     * @param {number} endOffset
+     * @return {number[]}
+     */
 opentype._parse.getBytes = function() {};
 
-/** @type {?} */
+/**
+     * Convert bytes to a string.
+     * @alias opentype._parse.bytesToString
+     * @param {number[]} bytes
+     * @return {string}
+     */
 opentype._parse.bytesToString = function() {};
 
-/** @type {?} */
+/**
+     * Parser constructor.
+     * @alias opentype._parse.Parser
+     * @constructor
+     * @param {DataView} data
+     * @param {number=} offset
+     */
 opentype._parse.Parser = function() {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
         "ot": "bin/ot"
       },
       "devDependencies": {
+        "acorn": "^8.16.0",
+        "acorn-walk": "^8.3.5",
+        "comment-parser": "^0.7.6",
         "esbuild": "^0.23.1",
         "eslint": "^9.10.0",
         "mocha": "^11.7.5"
@@ -615,10 +618,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -633,6 +637,19 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -823,6 +840,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/comment-parser": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
+      "integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2583,9 +2610,9 @@
       "optional": true
     },
     "acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -2594,6 +2621,15 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.11.0"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -2735,6 +2771,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "comment-parser": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
+      "integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
       "dev": true
     },
     "concat-map": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "browser": "./dist/opentype.js",
   "module": "./dist/opentype.mjs",
   "scripts": {
-    "build": "npm run b:umd && npm run b:esm",
+    "build": "npm run b:umd && npm run b:esm && npm run b:externs",
     "dist": " npm run d:umd && npm run d:esm",
     "test": "npm run build && npm run dist && mocha --recursive && npm run lint",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -30,15 +30,19 @@
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",
     "start": "esbuild --bundle src/opentype.mjs --outdir=dist --target=es2018 --format=esm  --out-extension:.js=.mjs     --define:DEBUG=false --global-name=opentype --watch --servedir=. --footer:js=\"(function (root, factory) { if (typeof define === 'function' && define.amd)define(factory); else if (typeof module === 'object' && module.exports)module.exports = factory(); else root.opentype = factory(); }(typeof self !== 'undefined' ? self : this, () => ({...opentype,'default':opentype})));\" --footer:js=\"new EventSource('/esbuild').addEventListener('change', () => location.reload())\"",
+    "b:externs": "node scripts/generate-externs.mjs",
     "b:umd": "esbuild --bundle src/opentype.mjs --outdir=dist --target=es2018 --format=iife --out-extension:.js=.js      --define:DEBUG=false --global-name=opentype                      --footer:js=\"(function (root, factory) { if (typeof define === 'function' && define.amd)define(factory); else if (typeof module === 'object' && module.exports)module.exports = factory(); else root.opentype = factory(); }(typeof self !== 'undefined' ? self : this, () => ({...opentype,'default':opentype})));\"",
     "d:umd": "esbuild --bundle src/opentype.mjs --outdir=dist --target=es2018 --format=iife --out-extension:.js=.min.js  --define:DEBUG=false --global-name=opentype --minify --sourcemap --footer:js=\"(function (root, factory) { if (typeof define === 'function' && define.amd)define(factory); else if (typeof module === 'object' && module.exports)module.exports = factory(); else root.opentype = factory(); }(typeof self !== 'undefined' ? self : this, () => ({...opentype,'default':opentype})));\"",
     "b:esm": "esbuild --bundle src/opentype.mjs --outdir=dist --target=es2018 --format=esm  --out-extension:.js=.mjs     --define:DEBUG=false",
     "d:esm": "esbuild --bundle src/opentype.mjs --outdir=dist --target=es2018 --format=esm  --out-extension:.js=.min.mjs --define:DEBUG=false --minify --sourcemap"
   },
   "devDependencies": {
-    "mocha": "^11.7.5",
+    "acorn": "^8.16.0",
+    "acorn-walk": "^8.3.5",
+    "comment-parser": "^0.7.6",
     "esbuild": "^0.23.1",
-    "eslint": "^9.10.0"
+    "eslint": "^9.10.0",
+    "mocha": "^11.7.5"
   },
   "bin": {
     "ot": "./bin/ot"

--- a/scripts/generate-externs.mjs
+++ b/scripts/generate-externs.mjs
@@ -1,0 +1,675 @@
+#!/usr/bin/env node
+
+/**
+ * Generate Closure externs for opentype.js from source JSDoc comments.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import * as acorn from 'acorn';
+import { simple as walkSimple } from 'acorn-walk';
+import commentParser from 'comment-parser';
+
+const parseComments = commentParser;
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC_DIR = path.join(ROOT, 'src');
+const EXTERNS_PATH = path.join(ROOT, 'externs', 'opentype.js');
+const ENTRY_FILE = path.join(SRC_DIR, 'opentype.mjs');
+
+/**
+ * Entry point for the extern generation script.
+ *
+ * Reads source files, determines public API symbols, and writes externs.
+ */
+async function main() {
+  const sourceFiles = await collectSourceFiles(SRC_DIR);
+  const fileInfos = await Promise.all(sourceFiles.map(parseSourceFile));
+  const exportedSymbols = collectExportedSymbols(fileInfos, ENTRY_FILE);
+  const opentypeAssignmentsSet = new Set(
+    fileInfos.flatMap((fi) => (fi.opentypeAssignments || []).map((a) => a.memberName))
+  );
+
+  const {
+    publicLocalNames,
+    publicTopLevelNames,
+    publicOpentypePaths,
+    localNameToOpentypePaths,
+  } = buildPublicSymbolInfo(fileInfos, exportedSymbols, ENTRY_FILE, opentypeAssignmentsSet);
+
+  const { docs: localDocs, protoDocs } = buildLocalDocs(
+    fileInfos,
+    exportedSymbols,
+    opentypeAssignmentsSet,
+    publicLocalNames,
+    publicTopLevelNames,
+    publicOpentypePaths,
+    localNameToOpentypePaths
+  );
+
+  const missingDocs = exportedSymbols
+    .filter((symbol) => !symbol.exportedName.startsWith('_'))
+    .filter((symbol) => !localDocs.has(symbol.localName))
+    .map((symbol) => `${symbol.exportedName} (local: ${symbol.localName})`);
+
+  if (missingDocs.length > 0) {
+    throw new Error(
+      `Missing JSDoc comments for public symbols exported by ${path.relative(ROOT, ENTRY_FILE)}:\n` +
+      missingDocs.join('\n')
+    );
+  }
+
+  const entries = buildExternEntries(localDocs, protoDocs, exportedSymbols, publicOpentypePaths);
+  const externSource = renderExternSource(entries);
+  await fs.writeFile(EXTERNS_PATH, externSource, 'utf8');
+  console.log(`Wrote ${path.relative(ROOT, EXTERNS_PATH)}`);
+}
+
+/**
+ * Collect all `.mjs` files recursively from the source directory.
+ *
+ * @param {string} directory
+ * @returns {Promise<string[]>}
+ */
+async function collectSourceFiles(directory) {
+  const dirents = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const dirent of dirents) {
+    const resolved = path.join(directory, dirent.name);
+    if (dirent.isDirectory()) {
+      files.push(...await collectSourceFiles(resolved));
+    } else if (dirent.isFile() && resolved.endsWith('.mjs')) {
+      files.push(resolved);
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Parse a source file and collect AST metadata used for extern generation.
+ *
+ * @param {string} filePath
+ * @returns {Promise<object>}
+ */
+async function parseSourceFile(filePath) {
+  const code = await fs.readFile(filePath, 'utf8');
+  const comments = [];
+  const ast = acorn.parse(code, {
+    sourceType: 'module',
+    ecmaVersion: 'latest',
+    onComment: comments,
+  });
+
+  const exports = [];
+  const declarations = new Map();
+  const prototypeAssignments = [];
+  const opentypeAssignments = [];
+  const imports = [];
+  const defaultExportProperties = [];
+
+  function isPrototypeMemberAssignment(node) {
+    return node.type === 'AssignmentExpression' &&
+      node.left.type === 'MemberExpression' &&
+      !node.left.computed &&
+      node.left.object.type === 'MemberExpression' &&
+      !node.left.object.computed &&
+      node.left.object.property.type === 'Identifier' &&
+      node.left.object.property.name === 'prototype' &&
+      node.left.object.object.type === 'Identifier' &&
+      node.left.property.type === 'Identifier';
+  }
+
+  function getOpentypeMemberPath(memberExpr) {
+    const parts = [];
+    let cur = memberExpr;
+
+    while (cur && cur.type === 'MemberExpression') {
+      if (cur.property.type === 'Identifier') {
+        parts.unshift(cur.property.name);
+      } else if (cur.property.type === 'Literal' && typeof cur.property.value === 'string') {
+        parts.unshift(cur.property.value);
+      } else {
+        return null;
+      }
+      cur = cur.object;
+    }
+
+    if (cur && cur.type === 'Identifier' && cur.name === 'opentype') {
+      return parts.join('.');
+    }
+    return null;
+  }
+
+  walkSimple(ast, {
+    FunctionDeclaration(node) {
+      if (node.id && node.id.name) {
+        declarations.set(node.id.name, node);
+      }
+    },
+    ClassDeclaration(node) {
+      if (node.id && node.id.name) {
+        declarations.set(node.id.name, node);
+      }
+    },
+    VariableDeclaration(node) {
+      for (const decl of node.declarations) {
+        if (decl.id && decl.id.type === 'Identifier' && decl.init) {
+          const name = decl.id.name;
+          if (decl.init.type === 'FunctionExpression' || decl.init.type === 'ClassExpression') {
+            declarations.set(name, node);
+          }
+        }
+      }
+    },
+    AssignmentExpression(node) {
+      if (isPrototypeMemberAssignment(node)) {
+        const className = node.left.object.object.name;
+        const memberName = node.left.property.name;
+        prototypeAssignments.push({
+          className,
+          memberName,
+          key: `${className}.prototype.${memberName}`,
+          node,
+        });
+      } else if (node.left && node.left.type === 'MemberExpression') {
+        const path = getOpentypeMemberPath(node.left);
+        if (path) {
+          opentypeAssignments.push({ memberName: path, node });
+        }
+      }
+    },
+    ImportDeclaration(node) {
+      const src = node.source && node.source.value;
+      for (const specifier of node.specifiers || []) {
+        if (specifier.type === 'ImportDefaultSpecifier') {
+          imports.push({ localName: specifier.local.name, importedName: 'default', source: src });
+        } else if (specifier.type === 'ImportSpecifier') {
+          imports.push({ localName: specifier.local.name, importedName: specifier.imported.name, source: src });
+        } else if (specifier.type === 'ImportNamespaceSpecifier') {
+          imports.push({ localName: specifier.local.name, importedName: '*', source: src });
+        }
+      }
+    },
+    ExportNamedDeclaration(node) {
+      if (node.declaration) {
+        if (node.declaration.type === 'FunctionDeclaration' && node.declaration.id) {
+          exports.push({ localName: node.declaration.id.name, exportedName: node.declaration.id.name });
+        } else if (node.declaration.type === 'ClassDeclaration' && node.declaration.id) {
+          exports.push({ localName: node.declaration.id.name, exportedName: node.declaration.id.name });
+        }
+      }
+      for (const specifier of node.specifiers || []) {
+        if (specifier.local && specifier.exported) {
+          exports.push({ localName: specifier.local.name, exportedName: specifier.exported.name });
+        }
+      }
+    },
+    ExportDefaultDeclaration(node) {
+      if (node.declaration && node.declaration.type === 'Identifier') {
+        exports.push({ localName: node.declaration.name, exportedName: 'default' });
+      } else if (node.declaration && node.declaration.type === 'ObjectExpression') {
+        for (const prop of node.declaration.properties || []) {
+          if (prop.type !== 'Property') continue;
+          const key = prop.key.type === 'Identifier'
+            ? prop.key.name
+            : (prop.key.type === 'Literal' ? String(prop.key.value) : null);
+          let localName = null;
+          if (prop.value && prop.value.type === 'Identifier') {
+            localName = prop.value.name;
+          }
+          if (key) defaultExportProperties.push({ name: key, localName });
+        }
+      }
+    },
+  });
+
+  return {
+    filePath,
+    code,
+    comments,
+    exports,
+    declarations,
+    prototypeAssignments,
+    opentypeAssignments,
+    imports,
+    defaultExportProperties,
+  };
+}
+
+/**
+ * Resolve a relative import source to an absolute file path.
+ *
+ * @param {string} baseFilePath
+ * @param {string} source
+ * @returns {string}
+ */
+function resolveImportSource(baseFilePath, source) {
+  if (source.startsWith('.')) {
+    let resolved = path.resolve(path.dirname(baseFilePath), source);
+    if (!path.extname(resolved)) {
+      resolved += '.mjs';
+    }
+    return resolved;
+  }
+  return source;
+}
+
+/**
+ * Build metadata for public symbols and their runtime namespace paths.
+ *
+ * @param {Array<object>} fileInfos
+ * @param {Array<object>} exportedSymbols
+ * @param {string} entryFile
+ * @param {Set<string>} opentypeAssignmentsSet
+ * @returns {object}
+ */
+function buildPublicSymbolInfo(fileInfos, exportedSymbols, entryFile, opentypeAssignmentsSet) {
+  const fileInfoByPath = new Map(fileInfos.map((info) => [path.resolve(info.filePath), info]));
+  const entry = fileInfoByPath.get(path.resolve(entryFile));
+  if (!entry) {
+    throw new Error(`Entry file not found: ${entryFile}`);
+  }
+
+  const publicLocalNames = new Set((exportedSymbols || []).map((s) => s.localName));
+  const publicTopLevelNames = new Set((exportedSymbols || []).map((s) => (s.exportedName === 'default' ? 'opentype' : s.exportedName)));
+  const publicOpentypePaths = new Set();
+  const localNameToOpentypePaths = new Map();
+
+  function addLocalPath(localName, pathName) {
+    if (!localName) return;
+    const paths = localNameToOpentypePaths.get(localName) || [];
+    if (!paths.includes(pathName)) {
+      paths.push(pathName);
+      localNameToOpentypePaths.set(localName, paths);
+    }
+  }
+
+  for (const symbol of exportedSymbols) {
+    if (symbol.exportedName !== 'default') {
+      addLocalPath(symbol.localName, `opentype.${symbol.exportedName}`);
+    }
+  }
+
+  for (const symbol of exportedSymbols) {
+    const importEntry = entry.imports.find((imp) => imp.localName === symbol.localName);
+    if (!importEntry || importEntry.importedName !== 'default') {
+      continue;
+    }
+
+    const resolvedSource = resolveImportSource(entry.filePath, importEntry.source);
+    const sourceInfo = fileInfoByPath.get(resolvedSource);
+    if (!sourceInfo) {
+      continue;
+    }
+
+    for (const prop of sourceInfo.defaultExportProperties) {
+      if (!prop.name) continue;
+      const nestedPath = `opentype.${symbol.exportedName}.${prop.name}`;
+      publicOpentypePaths.add(nestedPath);
+      if (prop.localName) {
+        publicLocalNames.add(prop.localName);
+        addLocalPath(prop.localName, nestedPath);
+        if (prop.name === 'Parser') {
+          addLocalPath(prop.localName, `opentype.${symbol.exportedName}`);
+        }
+      } else {
+        addLocalPath(prop.name, nestedPath);
+      }
+    }
+  }
+
+  for (const memberName of opentypeAssignmentsSet) {
+    const fullName = memberName.startsWith('opentype.') ? memberName : `opentype.${memberName}`;
+    publicOpentypePaths.add(fullName);
+    const root = memberName.split('.')[0];
+    publicTopLevelNames.add(root);
+    const lastSegment = memberName.split('.').slice(-1)[0];
+    publicLocalNames.add(lastSegment);
+  }
+
+  return { publicLocalNames, publicTopLevelNames, publicOpentypePaths, localNameToOpentypePaths };
+}
+
+/**
+ * Parse a JSDoc block comment and return the target symbol metadata.
+ *
+ * @param {string} source
+ * @returns {{kind:string,key:string|null,private:boolean}|null}
+ */
+function parseCommentDoc(source) {
+  const parsed = parseComments(source, { trim: true, spacing: 'preserve' });
+  if (parsed.length === 0) {
+    return null;
+  }
+
+  const block = parsed[0];
+  const aliasTag = block.tags.find((tag) => tag.tag === 'alias' || tag.tag === 'exports');
+  const typedefTag = block.tags.find((tag) => tag.tag === 'typedef');
+  const privateTag = block.tags.find((tag) => tag.tag === 'private');
+
+  if (typedefTag && typedefTag.name) {
+    return { kind: 'typedef', key: typedefTag.name, private: !!privateTag };
+  }
+
+  if (aliasTag && aliasTag.name) {
+    return { kind: 'property', key: aliasTag.name, private: !!privateTag };
+  }
+
+  const memberofTag = block.tags.find((tag) => tag.tag === 'memberof');
+  const functionTag = block.tags.find((tag) => tag.tag === 'function');
+  if (memberofTag && memberofTag.name && functionTag && functionTag.name) {
+    return { kind: 'property', key: `${memberofTag.name}.${functionTag.name}`, private: !!privateTag };
+  }
+
+  return { kind: 'property', key: null, private: !!privateTag };
+}
+
+/**
+ * Find the closest preceding JSDoc comment for a node.
+ *
+ * @param {Array<object>} comments
+ * @param {string} code
+ * @param {number} nodeStart
+ * @returns {object|null}
+ */
+function findJSDocComment(comments, code, nodeStart) {
+  const candidates = comments
+    .filter((comment) => comment.type === 'Block' && comment.end <= nodeStart && comment.value.startsWith('*'))
+    .sort((a, b) => b.end - a.end);
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const comment = candidates[0];
+  const gap = code.slice(comment.end, nodeStart);
+  if (/^[\s]*$/.test(gap)) {
+    return comment;
+  }
+
+  return null;
+}
+
+/**
+ * Build documentation records for all public local symbols and prototype members.
+ *
+ * @param {Array<object>} fileInfos
+ * @param {Array<object>} exportedSymbols
+ * @param {Set<string>} opentypeAssignmentsSet
+ * @param {Set<string>} publicLocalNames
+ * @param {Set<string>} publicTopLevelNames
+ * @param {Set<string>} publicOpentypePaths
+ * @param {Map<string,string[]>} localNameToOpentypePaths
+ * @returns {{docs:Map<string,object>,protoDocs:Array<object>}}
+ */
+function buildLocalDocs(
+  fileInfos,
+  exportedSymbols,
+  opentypeAssignmentsSet,
+  publicLocalNames,
+  publicTopLevelNames,
+  publicOpentypePaths,
+  localNameToOpentypePaths
+) {
+  const docs = new Map();
+  const protoDocs = [];
+
+  function isNamePublic(name) {
+    return (
+      publicLocalNames.has(name) ||
+      publicTopLevelNames.has(name) ||
+      publicOpentypePaths.has(name) ||
+      (opentypeAssignmentsSet && opentypeAssignmentsSet.has(name))
+    );
+  }
+
+  for (const fileInfo of fileInfos) {
+    const { code, comments, declarations, prototypeAssignments, filePath } = fileInfo;
+
+    for (const comment of comments) {
+      if (comment.type !== 'Block' || !comment.value.startsWith('*')) {
+        continue;
+      }
+
+      const source = `/*${comment.value}*/`;
+      const parsedTag = parseCommentDoc(source);
+      if (!parsedTag) continue;
+
+      if (parsedTag.kind === 'typedef') {
+        if (!parsedTag.private) {
+          docs.set(parsedTag.key, { source, kind: 'typedef', filePath });
+        }
+        continue;
+      }
+
+      if (parsedTag.private) {
+        continue;
+      }
+
+      if (parsedTag.key) {
+        if (parsedTag.key.startsWith('opentype.')) {
+          const rest = parsedTag.key.slice('opentype.'.length);
+          if (rest.includes('.prototype.')) {
+            const cls = rest.split('.prototype.')[0];
+            if (!isNamePublic(cls)) continue;
+            docs.set(parsedTag.key, { source, filePath });
+            protoDocs.push({
+              className: cls,
+              memberName: rest.split('.prototype.')[1],
+              targetName: parsedTag.key,
+              comment: source,
+            });
+          } else {
+            const name = rest.split('.')[0];
+            if (!isNamePublic(name)) continue;
+            docs.set(parsedTag.key, { source, filePath });
+          }
+        } else {
+          docs.set(parsedTag.key, { source, filePath });
+          if (parsedTag.key.includes('.prototype.')) {
+            protoDocs.push({
+              className: parsedTag.key.split('.prototype.')[0],
+              memberName: parsedTag.key.split('.prototype.')[1],
+              targetName: parsedTag.key,
+              comment: source,
+            });
+          }
+        }
+      }
+    }
+
+    for (const [name, node] of declarations) {
+      if (docs.has(name)) continue;
+      const comment = findJSDocComment(comments, code, node.start);
+      if (!comment) continue;
+
+      const source = `/*${comment.value}*/`;
+      const parsedTag = parseCommentDoc(source);
+      if (parsedTag && parsedTag.private) continue;
+
+      docs.set(name, { source, localName: name, filePath });
+    }
+
+    for (const assignment of prototypeAssignments) {
+      if (!isNamePublic(assignment.className)) continue;
+      const classPaths = [...new Set(localNameToOpentypePaths.get(assignment.className) || [])];
+      const comment = findJSDocComment(comments, code, assignment.node.start);
+      const source = comment ? `/*${comment.value}*/` : null;
+      let parsedTag = null;
+      if (source) {
+        parsedTag = parseCommentDoc(source);
+        if (parsedTag && parsedTag.private) continue;
+      }
+
+      const targets = [];
+      if (parsedTag && parsedTag.key && parsedTag.key.includes('.prototype.')) {
+        const targetName = parsedTag.key.startsWith('opentype.')
+          ? parsedTag.key
+          : `opentype.${parsedTag.key}`;
+        const rest = targetName.slice('opentype.'.length);
+        const cls = rest.split('.prototype.')[0];
+        if (isNamePublic(cls)) {
+          targets.push(targetName);
+        }
+      }
+
+      if (classPaths.length > 0) {
+        classPaths.sort((a, b) => a.length - b.length);
+        targets.push(`${classPaths[0]}.prototype.${assignment.memberName}`);
+      }
+
+      if (targets.length === 0) {
+        targets.push(`opentype.${assignment.className}.prototype.${assignment.memberName}`);
+      }
+
+      for (const targetName of targets) {
+        if (docs.has(targetName)) continue;
+        if (source) {
+          docs.set(targetName, { source, filePath });
+        }
+        protoDocs.push({
+          className: assignment.className,
+          memberName: assignment.memberName,
+          targetName,
+          comment: source,
+        });
+      }
+    }
+  }
+
+  for (const [localName, paths] of localNameToOpentypePaths) {
+    if (!isNamePublic(localName)) continue;
+    const localDoc = docs.get(localName) || docs.get(`opentype.${localName}`);
+    if (!localDoc) continue;
+
+    for (const nestedPath of paths) {
+      if (docs.has(nestedPath)) continue;
+      docs.set(nestedPath, {
+        source: localDoc.source,
+        filePath: localDoc.filePath,
+        kind: localDoc.kind,
+      });
+    }
+  }
+
+  return { docs, protoDocs };
+}
+
+function collectExportedSymbols(fileInfos, entryFile) {
+  const entry = fileInfos.find((info) => path.resolve(info.filePath) === path.resolve(entryFile));
+  if (!entry) {
+    throw new Error(`Entry file not found: ${entryFile}`);
+  }
+  return entry.exports;
+}
+
+function buildExternEntries(localDocs, protoDocs, exportedSymbols, publicOpentypePaths) {
+  const entries = [];
+  const seen = new Set();
+
+  for (const symbol of exportedSymbols) {
+    const { localName, exportedName } = symbol;
+    const doc = localDocs.get(localName) || localDocs.get(exportedName) || localDocs.get(`opentype.${exportedName}`);
+    const name = exportedName === 'default' ? 'opentype' : `opentype.${exportedName}`;
+
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+
+    if (doc) {
+      if (doc.kind === 'typedef') {
+        entries.push({ kind: 'typedef', name: exportedName, comment: doc.source });
+      } else {
+        entries.push({ kind: 'property', name, comment: doc.source });
+      }
+    } else {
+      entries.push({ kind: 'property', name, comment: null });
+    }
+  }
+
+  for (const protoDoc of protoDocs) {
+    if (!documentHasPublicClass(protoDoc.className, exportedSymbols, publicOpentypePaths)) {
+      continue;
+    }
+    const targetName = protoDoc.targetName.startsWith('opentype.')
+      ? protoDoc.targetName
+      : `opentype.${protoDoc.targetName}`;
+    if (seen.has(targetName)) {
+      continue;
+    }
+    seen.add(targetName);
+    entries.push({ kind: 'property', name: targetName, comment: protoDoc.comment });
+  }
+
+  for (const [name, doc] of localDocs) {
+    if (name.startsWith('opentype.') && !seen.has(name)) {
+      seen.add(name);
+      entries.push({ kind: 'property', name, comment: doc.source });
+    }
+  }
+
+  for (const pathName of publicOpentypePaths) {
+    if (!pathName.startsWith('opentype.')) continue;
+    if (seen.has(pathName)) continue;
+    seen.add(pathName);
+    entries.push({ kind: 'property', name: pathName, comment: null });
+  }
+
+  return entries;
+}
+
+function documentHasPublicClass(className, exportedSymbols, publicOpentypePaths) {
+  if (exportedSymbols.some((symbol) => symbol.localName === className)) {
+    return true;
+  }
+  for (const pathName of publicOpentypePaths) {
+    if (pathName.endsWith(`.${className}`) || pathName.includes(`.${className}.`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function renderExternSource(entries) {
+  const lines = [
+    '/**',
+    ' * @fileoverview Closure Compiler externs for opentype.js generated from source JSDoc.',
+    ' * @externs',
+    ' */',
+    '',
+    '/** @const */',
+    'var opentype = {};',
+    '',
+  ];
+
+  for (const entry of entries) {
+    if (entry.kind === 'typedef') {
+      lines.push(entry.comment);
+      lines.push(`var ${entry.name};`);
+      lines.push('');
+      continue;
+    }
+
+    if (entry.comment) {
+      lines.push(entry.comment);
+    } else {
+      lines.push('/** @type {?} */');
+    }
+    lines.push(`${entry.name} = function() {};`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+export default main;

--- a/scripts/generate-externs.mjs
+++ b/scripts/generate-externs.mjs
@@ -27,7 +27,7 @@ async function main() {
   const fileInfos = await Promise.all(sourceFiles.map(parseSourceFile));
   const exportedSymbols = collectExportedSymbols(fileInfos, ENTRY_FILE);
   const opentypeAssignmentsSet = new Set(
-    fileInfos.flatMap((fi) => (fi.opentypeAssignments || []).map((a) => a.memberName))
+    fileInfos.flatMap((info) => (info.opentypeAssignments || []).map((assignment) => assignment.memberName))
   );
 
   const {
@@ -48,13 +48,14 @@ async function main() {
   );
 
   const missingDocs = exportedSymbols
-    .filter((symbol) => !symbol.exportedName.startsWith('_'))
+    .filter((symbol) => !(symbol.exportedName.startsWith('_') || symbol.exportedName.startsWith('#')))
     .filter((symbol) => !localDocs.has(symbol.localName))
     .map((symbol) => `${symbol.exportedName} (local: ${symbol.localName})`);
 
   if (missingDocs.length > 0) {
     throw new Error(
-      `Missing JSDoc comments for public symbols exported by ${path.relative(ROOT, ENTRY_FILE)}:\n` +
+      `Missing JSDoc comments for public symbols exported by ${path.relative(ROOT, ENTRY_FILE)}:` +
+      '\n' +
       missingDocs.join('\n')
     );
   }
@@ -70,6 +71,11 @@ async function main() {
  *
  * @param {string} directory
  * @returns {Promise<string[]>}
+ */
+/**
+ * Recursively collect all `.mjs` source files under a directory.
+ * @param {string} directory - Directory to search.
+ * @returns {Promise<string[]>} Resolved list of absolute file paths.
  */
 async function collectSourceFiles(directory) {
   const dirents = await fs.readdir(directory, { withFileTypes: true });
@@ -92,6 +98,17 @@ async function collectSourceFiles(directory) {
  *
  * @param {string} filePath
  * @returns {Promise<object>}
+ */
+/**
+ * Parse a single source file and extract AST-derived metadata used for
+ * extern generation.
+ *
+ * The returned object contains the raw `code` and parsed `comments`, a list
+ * of `exports`, named `declarations`, prototype and `opentypeAssignments`,
+ * `imports` and properties related to default exports.
+ *
+ * @param {string} filePath - Absolute path to the source file.
+ * @returns {Promise<object>} Metadata describing the file's AST items.
  */
 async function parseSourceFile(filePath) {
   const code = await fs.readFile(filePath, 'utf8');
@@ -121,6 +138,29 @@ async function parseSourceFile(filePath) {
       node.left.property.type === 'Identifier';
   }
 
+  function isThisMemberAssignment(node) {
+    return node.type === 'AssignmentExpression' &&
+      node.left.type === 'MemberExpression' &&
+      !node.left.computed &&
+      node.left.object.type === 'ThisExpression' &&
+      node.left.property.type === 'Identifier';
+  }
+
+  function collectConstructorAssignments(body, className) {
+    if (!body || body.type !== 'BlockStatement') return;
+    walkSimple(body, {
+      AssignmentExpression(node) {
+        if (!isThisMemberAssignment(node)) return;
+        prototypeAssignments.push({
+          className,
+          memberName: node.left.property.name,
+          key: `${className}.prototype.${node.left.property.name}`,
+          node,
+        });
+      },
+    });
+  }
+
   function getOpentypeMemberPath(memberExpr) {
     const parts = [];
     let cur = memberExpr;
@@ -144,21 +184,28 @@ async function parseSourceFile(filePath) {
 
   walkSimple(ast, {
     FunctionDeclaration(node) {
-      if (node.id && node.id.name) {
+      if (node.id?.name) {
         declarations.set(node.id.name, node);
+        collectConstructorAssignments(node.body, node.id.name);
       }
     },
     ClassDeclaration(node) {
-      if (node.id && node.id.name) {
+      if (node.id?.name) {
         declarations.set(node.id.name, node);
+      }
+      for (const element of node.body.body || []) {
+        if (element.type === 'MethodDefinition' && element.kind === 'constructor') {
+          collectConstructorAssignments(element.value.body, node.id.name);
+        }
       }
     },
     VariableDeclaration(node) {
       for (const decl of node.declarations) {
-        if (decl.id && decl.id.type === 'Identifier' && decl.init) {
+        if (decl.id?.type === 'Identifier' && decl.init) {
           const name = decl.id.name;
           if (decl.init.type === 'FunctionExpression' || decl.init.type === 'ClassExpression') {
             declarations.set(name, node);
+            collectConstructorAssignments(decl.init.body, name);
           }
         }
       }
@@ -173,7 +220,7 @@ async function parseSourceFile(filePath) {
           key: `${className}.prototype.${memberName}`,
           node,
         });
-      } else if (node.left && node.left.type === 'MemberExpression') {
+      } else if (node.left?.type === 'MemberExpression') {
         const path = getOpentypeMemberPath(node.left);
         if (path) {
           opentypeAssignments.push({ memberName: path, node });
@@ -181,7 +228,7 @@ async function parseSourceFile(filePath) {
       }
     },
     ImportDeclaration(node) {
-      const src = node.source && node.source.value;
+      const src = node.source?.value;
       for (const specifier of node.specifiers || []) {
         if (specifier.type === 'ImportDefaultSpecifier') {
           imports.push({ localName: specifier.local.name, importedName: 'default', source: src });
@@ -194,9 +241,9 @@ async function parseSourceFile(filePath) {
     },
     ExportNamedDeclaration(node) {
       if (node.declaration) {
-        if (node.declaration.type === 'FunctionDeclaration' && node.declaration.id) {
+        if (node.declaration.type === 'FunctionDeclaration' && node.declaration.id?.name) {
           exports.push({ localName: node.declaration.id.name, exportedName: node.declaration.id.name });
-        } else if (node.declaration.type === 'ClassDeclaration' && node.declaration.id) {
+        } else if (node.declaration.type === 'ClassDeclaration' && node.declaration.id?.name) {
           exports.push({ localName: node.declaration.id.name, exportedName: node.declaration.id.name });
         }
       }
@@ -207,18 +254,16 @@ async function parseSourceFile(filePath) {
       }
     },
     ExportDefaultDeclaration(node) {
-      if (node.declaration && node.declaration.type === 'Identifier') {
+      if (node.declaration?.type === 'Identifier') {
         exports.push({ localName: node.declaration.name, exportedName: 'default' });
-      } else if (node.declaration && node.declaration.type === 'ObjectExpression') {
+      } else if (node.declaration?.type === 'ObjectExpression') {
         for (const prop of node.declaration.properties || []) {
           if (prop.type !== 'Property') continue;
           const key = prop.key.type === 'Identifier'
             ? prop.key.name
             : (prop.key.type === 'Literal' ? String(prop.key.value) : null);
           let localName = null;
-          if (prop.value && prop.value.type === 'Identifier') {
-            localName = prop.value.name;
-          }
+          if (prop.value?.type === 'Identifier') localName = prop.value.name;
           if (key) defaultExportProperties.push({ name: key, localName });
         }
       }
@@ -239,31 +284,49 @@ async function parseSourceFile(filePath) {
 }
 
 /**
- * Resolve a relative import source to an absolute file path.
+ * From the parsed file infos, collect the exported symbols declared by the
+ * library entry file. Filters out private exports (starting with `_`).
  *
- * @param {string} baseFilePath
- * @param {string} source
- * @returns {string}
+ * @param {Array<object>} fileInfos - Array of parsed file metadata.
+ * @param {string} entryFile - Absolute path to the entry file.
+ * @returns {Array<{localName:string, exportedName:string}>} Public exports.
  */
-function resolveImportSource(baseFilePath, source) {
-  if (source.startsWith('.')) {
-    let resolved = path.resolve(path.dirname(baseFilePath), source);
-    if (!path.extname(resolved)) {
-      resolved += '.mjs';
-    }
-    return resolved;
+function collectExportedSymbols(fileInfos, entryFile) {
+  const fileInfoByPath = new Map(fileInfos.map((info) => [path.resolve(info.filePath), info]));
+  const entry = fileInfoByPath.get(path.resolve(entryFile));
+  if (!entry) {
+    throw new Error(`Entry file not found: ${entryFile}`);
   }
-  return source;
+
+  return entry.exports.filter((symbol) => !(symbol.exportedName.startsWith('_') || symbol.exportedName.startsWith('#')));
 }
 
 /**
- * Build metadata for public symbols and their runtime namespace paths.
+ * Resolve an ES module import specifier to an absolute path when it is a
+ * local (relative) import. Non-relative imports are returned unchanged.
  *
- * @param {Array<object>} fileInfos
- * @param {Array<object>} exportedSymbols
- * @param {string} entryFile
- * @param {Set<string>} opentypeAssignmentsSet
- * @returns {object}
+ * @param {string} baseFilePath - File that contains the import.
+ * @param {string} source - The import source specifier from the AST.
+ * @returns {string} Resolved path or original module specifier.
+ */
+function resolveImportSource(baseFilePath, source) {
+  if (!source.startsWith('.')) return source;
+
+  let resolved = path.resolve(path.dirname(baseFilePath), source);
+  if (!path.extname(resolved)) resolved += '.mjs';
+  return resolved;
+}
+
+/**
+ * Build sets and maps describing which local symbols correspond to public
+ * `opentype.*` paths and which top-level names are exported.
+ *
+ * @param {Array<object>} fileInfos - Parsed file metadata.
+ * @param {Array<object>} exportedSymbols - Symbols exported by the entry.
+ * @param {string} entryFile - Entry file path.
+ * @param {Set<string>} opentypeAssignmentsSet - Set of member names assigned
+ *   on the `opentype` global in the codebase.
+ * @returns {{publicLocalNames:Set<string>,publicTopLevelNames:Set<string>,publicOpentypePaths:Set<string>,localNameToOpentypePaths:Map<string,string[]>}}
  */
 function buildPublicSymbolInfo(fileInfos, exportedSymbols, entryFile, opentypeAssignmentsSet) {
   const fileInfoByPath = new Map(fileInfos.map((info) => [path.resolve(info.filePath), info]));
@@ -272,8 +335,10 @@ function buildPublicSymbolInfo(fileInfos, exportedSymbols, entryFile, opentypeAs
     throw new Error(`Entry file not found: ${entryFile}`);
   }
 
-  const publicLocalNames = new Set((exportedSymbols || []).map((s) => s.localName));
-  const publicTopLevelNames = new Set((exportedSymbols || []).map((s) => (s.exportedName === 'default' ? 'opentype' : s.exportedName)));
+  const publicLocalNames = new Set(exportedSymbols.map((symbol) => symbol.localName));
+  const publicTopLevelNames = new Set(exportedSymbols.map((symbol) =>
+    symbol.exportedName === 'default' ? 'opentype' : symbol.exportedName
+  ));
   const publicOpentypePaths = new Set();
   const localNameToOpentypePaths = new Map();
 
@@ -294,20 +359,17 @@ function buildPublicSymbolInfo(fileInfos, exportedSymbols, entryFile, opentypeAs
 
   for (const symbol of exportedSymbols) {
     const importEntry = entry.imports.find((imp) => imp.localName === symbol.localName);
-    if (!importEntry || importEntry.importedName !== 'default') {
-      continue;
-    }
+    if (!importEntry || importEntry.importedName !== 'default') continue;
 
     const resolvedSource = resolveImportSource(entry.filePath, importEntry.source);
     const sourceInfo = fileInfoByPath.get(resolvedSource);
-    if (!sourceInfo) {
-      continue;
-    }
+    if (!sourceInfo) continue;
 
     for (const prop of sourceInfo.defaultExportProperties) {
       if (!prop.name) continue;
       const nestedPath = `opentype.${symbol.exportedName}.${prop.name}`;
       publicOpentypePaths.add(nestedPath);
+
       if (prop.localName) {
         publicLocalNames.add(prop.localName);
         addLocalPath(prop.localName, nestedPath);
@@ -323,85 +385,81 @@ function buildPublicSymbolInfo(fileInfos, exportedSymbols, entryFile, opentypeAs
   for (const memberName of opentypeAssignmentsSet) {
     const fullName = memberName.startsWith('opentype.') ? memberName : `opentype.${memberName}`;
     publicOpentypePaths.add(fullName);
-    const root = memberName.split('.')[0];
-    publicTopLevelNames.add(root);
-    const lastSegment = memberName.split('.').slice(-1)[0];
-    publicLocalNames.add(lastSegment);
+    publicTopLevelNames.add(memberName.split('.')[0]);
+    publicLocalNames.add(memberName.split('.').slice(-1)[0]);
   }
 
   return { publicLocalNames, publicTopLevelNames, publicOpentypePaths, localNameToOpentypePaths };
 }
 
 /**
- * Parse a JSDoc block comment and return the target symbol metadata.
+ * Parse a JSDoc comment block and extract a small set of tags the script
+ * uses to map docs to symbols (`@alias`, `@typedef`, `@memberof`, etc.).
  *
- * @param {string} source
+ * @param {string} source - Raw JSDoc source text (including the JSDoc delimiters).
  * @returns {{kind:string,key:string|null,private:boolean}|null}
  */
 function parseCommentDoc(source) {
   const parsed = parseComments(source, { trim: true, spacing: 'preserve' });
-  if (parsed.length === 0) {
-    return null;
-  }
+  if (parsed.length === 0) return null;
 
   const block = parsed[0];
   const aliasTag = block.tags.find((tag) => tag.tag === 'alias' || tag.tag === 'exports');
   const typedefTag = block.tags.find((tag) => tag.tag === 'typedef');
   const privateTag = block.tags.find((tag) => tag.tag === 'private');
 
-  if (typedefTag && typedefTag.name) {
-    return { kind: 'typedef', key: typedefTag.name, private: !!privateTag };
+  if (typedefTag?.name) {
+    return { kind: 'typedef', key: typedefTag.name, private: Boolean(privateTag) };
   }
 
-  if (aliasTag && aliasTag.name) {
-    return { kind: 'property', key: aliasTag.name, private: !!privateTag };
+  if (aliasTag?.name) {
+    return { kind: 'property', key: aliasTag.name, private: Boolean(privateTag) };
   }
 
   const memberofTag = block.tags.find((tag) => tag.tag === 'memberof');
   const functionTag = block.tags.find((tag) => tag.tag === 'function');
-  if (memberofTag && memberofTag.name && functionTag && functionTag.name) {
-    return { kind: 'property', key: `${memberofTag.name}.${functionTag.name}`, private: !!privateTag };
+  if (memberofTag?.name && functionTag?.name) {
+    return { kind: 'property', key: `${memberofTag.name}.${functionTag.name}`, private: Boolean(privateTag) };
   }
 
-  return { kind: 'property', key: null, private: !!privateTag };
+  return { kind: 'property', key: null, private: Boolean(privateTag) };
 }
 
 /**
- * Find the closest preceding JSDoc comment for a node.
+ * Find the nearest preceding JSDoc block comment for a node start offset.
+ * Returns the comment object from Acorn when the gap between comment end
+ * and node start contains only whitespace.
  *
- * @param {Array<object>} comments
- * @param {string} code
- * @param {number} nodeStart
- * @returns {object|null}
+ * @param {Array<object>} comments - Acorn onComment array for the file.
+ * @param {string} code - Source code text.
+ * @param {number} nodeStart - AST node `start` index.
+ * @returns {object|null} Matching comment or null.
  */
 function findJSDocComment(comments, code, nodeStart) {
   const candidates = comments
     .filter((comment) => comment.type === 'Block' && comment.end <= nodeStart && comment.value.startsWith('*'))
     .sort((a, b) => b.end - a.end);
 
-  if (candidates.length === 0) {
-    return null;
-  }
+  if (candidates.length === 0) return null;
 
   const comment = candidates[0];
   const gap = code.slice(comment.end, nodeStart);
-  if (/^[\s]*$/.test(gap)) {
-    return comment;
-  }
-
-  return null;
+  return /^[\s]*$/.test(gap) ? comment : null;
 }
 
 /**
- * Build documentation records for all public local symbols and prototype members.
+ * Build a map of local documentation blocks and prototype docs from the
+ * parsed files. This associates JSDoc comments with public/local symbol
+ * names and synthesizes prototype entries when necessary.
  *
- * @param {Array<object>} fileInfos
- * @param {Array<object>} exportedSymbols
- * @param {Set<string>} opentypeAssignmentsSet
- * @param {Set<string>} publicLocalNames
- * @param {Set<string>} publicTopLevelNames
- * @param {Set<string>} publicOpentypePaths
- * @param {Map<string,string[]>} localNameToOpentypePaths
+ * @param {Array<object>} fileInfos - Parsed file metadata.
+ * @param {Array<object>} exportedSymbols - Symbols exported by the entry.
+ * @param {Set<string>} opentypeAssignmentsSet - Names assigned to `opentype`.
+ * @param {Set<string>} publicLocalNames - Local symbol names considered public.
+ * @param {Set<string>} publicTopLevelNames - Top-level exported names.
+ * @param {Set<string>} publicOpentypePaths - Known `opentype.*` paths.
+ * @param {Map<string,string[]>} localNameToOpentypePaths - Mapping from local
+ *   names to nested `opentype.*` paths.
  * @returns {{docs:Map<string,object>,protoDocs:Array<object>}}
  */
 function buildLocalDocs(
@@ -421,7 +479,7 @@ function buildLocalDocs(
       publicLocalNames.has(name) ||
       publicTopLevelNames.has(name) ||
       publicOpentypePaths.has(name) ||
-      (opentypeAssignmentsSet && opentypeAssignmentsSet.has(name))
+      opentypeAssignmentsSet.has(name)
     );
   }
 
@@ -429,53 +487,45 @@ function buildLocalDocs(
     const { code, comments, declarations, prototypeAssignments, filePath } = fileInfo;
 
     for (const comment of comments) {
-      if (comment.type !== 'Block' || !comment.value.startsWith('*')) {
-        continue;
-      }
+      if (comment.type !== 'Block' || !comment.value.startsWith('*')) continue;
 
       const source = `/*${comment.value}*/`;
       const parsedTag = parseCommentDoc(source);
-      if (!parsedTag) continue;
+      if (!parsedTag || parsedTag.private) continue;
 
       if (parsedTag.kind === 'typedef') {
-        if (!parsedTag.private) {
-          docs.set(parsedTag.key, { source, kind: 'typedef', filePath });
-        }
+        docs.set(parsedTag.key, { source, kind: 'typedef', filePath, private: false });
         continue;
       }
 
-      if (parsedTag.private) {
-        continue;
-      }
+      if (!parsedTag.key) continue;
 
-      if (parsedTag.key) {
-        if (parsedTag.key.startsWith('opentype.')) {
-          const rest = parsedTag.key.slice('opentype.'.length);
-          if (rest.includes('.prototype.')) {
-            const cls = rest.split('.prototype.')[0];
-            if (!isNamePublic(cls)) continue;
-            docs.set(parsedTag.key, { source, filePath });
-            protoDocs.push({
-              className: cls,
-              memberName: rest.split('.prototype.')[1],
-              targetName: parsedTag.key,
-              comment: source,
-            });
-          } else {
-            const name = rest.split('.')[0];
-            if (!isNamePublic(name)) continue;
-            docs.set(parsedTag.key, { source, filePath });
-          }
+      if (parsedTag.key.startsWith('opentype.')) {
+        const rest = parsedTag.key.slice('opentype.'.length);
+        if (rest.includes('.prototype.')) {
+          const cls = rest.split('.prototype.')[0];
+          if (!isNamePublic(cls)) continue;
+          docs.set(parsedTag.key, { source, filePath, private: false });
+          protoDocs.push({
+            className: cls,
+            memberName: rest.split('.prototype.')[1],
+            targetName: parsedTag.key,
+            comment: source,
+          });
         } else {
-          docs.set(parsedTag.key, { source, filePath });
-          if (parsedTag.key.includes('.prototype.')) {
-            protoDocs.push({
-              className: parsedTag.key.split('.prototype.')[0],
-              memberName: parsedTag.key.split('.prototype.')[1],
-              targetName: parsedTag.key,
-              comment: source,
-            });
-          }
+          const name = rest.split('.')[0];
+          if (!isNamePublic(name)) continue;
+          docs.set(parsedTag.key, { source, filePath, private: false });
+        }
+      } else {
+        docs.set(parsedTag.key, { source, filePath, private: false });
+        if (parsedTag.key.includes('.prototype.')) {
+          protoDocs.push({
+            className: parsedTag.key.split('.prototype.')[0],
+            memberName: parsedTag.key.split('.prototype.')[1],
+            targetName: parsedTag.key,
+            comment: source,
+          });
         }
       }
     }
@@ -487,32 +537,28 @@ function buildLocalDocs(
 
       const source = `/*${comment.value}*/`;
       const parsedTag = parseCommentDoc(source);
-      if (parsedTag && parsedTag.private) continue;
+      if (parsedTag?.private) continue;
 
-      docs.set(name, { source, localName: name, filePath });
+      docs.set(name, { source, localName: name, filePath, private: false });
     }
 
     for (const assignment of prototypeAssignments) {
       if (!isNamePublic(assignment.className)) continue;
+      if (assignment.memberName.startsWith('_') || assignment.memberName.startsWith('#')) continue;
+
       const classPaths = [...new Set(localNameToOpentypePaths.get(assignment.className) || [])];
       const comment = findJSDocComment(comments, code, assignment.node.start);
       const source = comment ? `/*${comment.value}*/` : null;
-      let parsedTag = null;
-      if (source) {
-        parsedTag = parseCommentDoc(source);
-        if (parsedTag && parsedTag.private) continue;
-      }
+      const parsedTag = source ? parseCommentDoc(source) : null;
+      if (parsedTag?.private) continue;
 
       const targets = [];
-      if (parsedTag && parsedTag.key && parsedTag.key.includes('.prototype.')) {
+      if (parsedTag?.key?.includes('.prototype.')) {
         const targetName = parsedTag.key.startsWith('opentype.')
           ? parsedTag.key
           : `opentype.${parsedTag.key}`;
-        const rest = targetName.slice('opentype.'.length);
-        const cls = rest.split('.prototype.')[0];
-        if (isNamePublic(cls)) {
-          targets.push(targetName);
-        }
+        const cls = targetName.slice('opentype.'.length).split('.prototype.')[0];
+        if (isNamePublic(cls)) targets.push(targetName);
       }
 
       if (classPaths.length > 0) {
@@ -526,9 +572,7 @@ function buildLocalDocs(
 
       for (const targetName of targets) {
         if (docs.has(targetName)) continue;
-        if (source) {
-          docs.set(targetName, { source, filePath });
-        }
+        if (source) docs.set(targetName, { source, filePath, private: false });
         protoDocs.push({
           className: assignment.className,
           memberName: assignment.memberName,
@@ -550,6 +594,7 @@ function buildLocalDocs(
         source: localDoc.source,
         filePath: localDoc.filePath,
         kind: localDoc.kind,
+        private: localDoc.private || false,
       });
     }
   }
@@ -557,26 +602,28 @@ function buildLocalDocs(
   return { docs, protoDocs };
 }
 
-function collectExportedSymbols(fileInfos, entryFile) {
-  const entry = fileInfos.find((info) => path.resolve(info.filePath) === path.resolve(entryFile));
-  if (!entry) {
-    throw new Error(`Entry file not found: ${entryFile}`);
-  }
-  return entry.exports;
-}
-
+/**
+ * Create the ordered list of extern entries (typedefs and properties)
+ * that will be rendered into the externs file. This function also ensures
+ * the entries are deduplicated and filtered by public visibility.
+ *
+ * @param {Map<string,object>} localDocs - Map of documentation blocks.
+ * @param {Array<object>} protoDocs - Prototype member doc descriptors.
+ * @param {Array<object>} exportedSymbols - Symbols exported by the entry.
+ * @param {Set<string>} publicOpentypePaths - Known `opentype.*` paths.
+ * @returns {Array<object>} Entries describing typedefs/properties for output.
+ */
 function buildExternEntries(localDocs, protoDocs, exportedSymbols, publicOpentypePaths) {
   const entries = [];
   const seen = new Set();
 
   for (const symbol of exportedSymbols) {
     const { localName, exportedName } = symbol;
-    const doc = localDocs.get(localName) || localDocs.get(exportedName) || localDocs.get(`opentype.${exportedName}`);
+    let doc = localDocs.get(localName) || localDocs.get(exportedName) || localDocs.get(`opentype.${exportedName}`);
     const name = exportedName === 'default' ? 'opentype' : `opentype.${exportedName}`;
 
-    if (seen.has(name)) {
-      continue;
-    }
+    if (doc?.private) doc = null;
+    if (seen.has(name)) continue;
     seen.add(name);
 
     if (doc) {
@@ -591,29 +638,37 @@ function buildExternEntries(localDocs, protoDocs, exportedSymbols, publicOpentyp
   }
 
   for (const protoDoc of protoDocs) {
-    if (!documentHasPublicClass(protoDoc.className, exportedSymbols, publicOpentypePaths)) {
-      continue;
-    }
+    if (!documentHasPublicClass(protoDoc.className, exportedSymbols, publicOpentypePaths)) continue;
+    if (protoDoc.memberName.startsWith('_')||protoDoc.memberName.startsWith('#')) continue;
+
     const targetName = protoDoc.targetName.startsWith('opentype.')
       ? protoDoc.targetName
       : `opentype.${protoDoc.targetName}`;
-    if (seen.has(targetName)) {
-      continue;
-    }
+    if (seen.has(targetName)) continue;
+
     seen.add(targetName);
     entries.push({ kind: 'property', name: targetName, comment: protoDoc.comment });
   }
 
+  const usedTypedefs = collectUsedTypedefNames(localDocs, entries);
   for (const [name, doc] of localDocs) {
-    if (name.startsWith('opentype.') && !seen.has(name)) {
-      seen.add(name);
-      entries.push({ kind: 'property', name, comment: doc.source });
-    }
+    if (!doc || doc.private || doc.kind !== 'typedef' || !usedTypedefs.has(name) || seen.has(name)) continue;
+    seen.add(name);
+    entries.push({ kind: 'typedef', name, comment: doc.source });
+  }
+
+  for (const [name, doc] of localDocs) {
+    if (!doc || doc.private || !name.startsWith('opentype.') || seen.has(name)) continue;
+    const lastComponent = name.split('.').pop();
+    if (lastComponent.startsWith('_') || lastComponent.startsWith('#')) continue;
+    seen.add(name);
+    entries.push({ kind: 'property', name, comment: doc.source });
   }
 
   for (const pathName of publicOpentypePaths) {
-    if (!pathName.startsWith('opentype.')) continue;
-    if (seen.has(pathName)) continue;
+    if (!pathName.startsWith('opentype.') || seen.has(pathName)) continue;
+    const lastComponent = pathName.split('.').pop();
+    if (lastComponent.startsWith('_') || lastComponent.startsWith('#')) continue;
     seen.add(pathName);
     entries.push({ kind: 'property', name: pathName, comment: null });
   }
@@ -621,18 +676,79 @@ function buildExternEntries(localDocs, protoDocs, exportedSymbols, publicOpentyp
   return entries;
 }
 
+/**
+ * Return true if a class name is present in the exported symbols or if it
+ * appears as part of any known public `opentype.*` path.
+ *
+ * @param {string} className
+ * @param {Array<object>} exportedSymbols
+ * @param {Set<string>} publicOpentypePaths
+ * @returns {boolean}
+ */
 function documentHasPublicClass(className, exportedSymbols, publicOpentypePaths) {
   if (exportedSymbols.some((symbol) => symbol.localName === className)) {
     return true;
   }
+
   for (const pathName of publicOpentypePaths) {
     if (pathName.endsWith(`.${className}`) || pathName.includes(`.${className}.`)) {
       return true;
     }
   }
+
   return false;
 }
 
+/**
+ * Compute the set of typedef names referenced by the collected entry
+ * comments. This iteratively expands typedefs referenced by other typedefs.
+ *
+ * @param {Map<string,object>} localDocs
+ * @param {Array<object>} entries
+ * @returns {Set<string>} Names of typedefs that are used.
+ */
+function collectUsedTypedefNames(localDocs, entries) {
+  const typedefNames = [...localDocs.keys()].filter((name) => localDocs.get(name)?.kind === 'typedef');
+  const used = new Set();
+  const sources = entries
+    .filter((entry) => entry.comment && entry.kind !== 'typedef')
+    .map((entry) => entry.comment);
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const name of typedefNames) {
+      if (used.has(name)) continue;
+      const regex = new RegExp(`\\b${escapeRegExp(name)}\\b`);
+      if (sources.some((source) => regex.test(source))) {
+        used.add(name);
+        const doc = localDocs.get(name);
+        if (doc?.source) sources.push(doc.source);
+        changed = true;
+      }
+    }
+  }
+
+  return used;
+}
+
+/**
+ * Escape a string so it may be used as a literal in a RegExp constructor.
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Render the externs file content from a list of entries. Each `property`
+ * entry becomes an assignment function on the `opentype` object; `typedef`
+ * entries are emitted as `var` declarations with their original comment.
+ *
+ * @param {Array<object>} entries
+ * @returns {string} File source for externs.
+ */
 function renderExternSource(entries) {
   const lines = [
     '/**',
@@ -645,19 +761,35 @@ function renderExternSource(entries) {
     '',
   ];
 
-  for (const entry of entries) {
-    if (entry.kind === 'typedef') {
-      lines.push(entry.comment);
-      lines.push(`var ${entry.name};`);
-      lines.push('');
-      continue;
-    }
+  // Helper: strip import()/include() wrappers from type expressions so
+  // the externs contain plain type names that Closure can understand.
+  function sanitizeComment(comment) {
+    if (!comment) return comment;
+    // Replace patterns like import('...').Type or include('...').Type -> Type
+    comment = comment.replace(/\b(?:import|include)\(\s*['"][^'"]+['"]\s*\)\.([A-Za-z0-9_$\.]+)/g, '$1');
+    // Remove bare import('...') or include('...') occurrences
+    comment = comment.replace(/\b(?:import|include)\(\s*['"][^'"]+['"]\s*\)/g, '');
+    return comment;
+  }
 
+  // Emit typedefs first so they are available to subsequent property entries.
+  const typedefEntries = entries.filter((e) => e.kind === 'typedef');
+  const otherEntries = entries.filter((e) => e.kind !== 'typedef');
+
+  for (const entry of typedefEntries) {
+    const comment = sanitizeComment(entry.comment) || '/** @type {?} */';
+    lines.push(comment);
+    lines.push(`var ${entry.name};`);
+    lines.push('');
+  }
+
+  for (const entry of otherEntries) {
     if (entry.comment) {
-      lines.push(entry.comment);
+      lines.push(sanitizeComment(entry.comment));
     } else {
       lines.push('/** @type {?} */');
     }
+
     lines.push(`${entry.name} = function() {};`);
     lines.push('');
   }
@@ -672,4 +804,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   });
 }
 
+/**
+ * Default export: run the main generator when invoked programmatically.
+ * @returns {Promise<void>}
+ */
 export default main;

--- a/src/bbox.mjs
+++ b/src/bbox.mjs
@@ -17,9 +17,25 @@ function derive(v0, v1, v2, v3, t) {
  * @constructor
  */
 function BoundingBox() {
+    /**
+     * The minimum X coordinate of the bounding box.
+     * @type {number}
+     */
     this.x1 = Number.NaN;
+    /**
+     * The minimum Y coordinate of the bounding box.
+     * @type {number}
+     */
     this.y1 = Number.NaN;
+    /**
+     * The maximum X coordinate of the bounding box.
+     * @type {number}
+     */
     this.x2 = Number.NaN;
+    /**
+     * The maximum Y coordinate of the bounding box.
+     * @type {number}
+     */
     this.y2 = Number.NaN;
 }
 

--- a/src/font.mjs
+++ b/src/font.mjs
@@ -14,6 +14,25 @@ import HintingTrueType from './hintingtt.mjs';
 import Bidi from './bidi.mjs';
 import { applyPaintType } from './tables/cff.mjs';
 
+/**
+ * @typedef NamePlatform
+ * @type {{
+ *      fontFamily: Object<string,string>,
+ *      fontSubfamily: Object<string,string>,
+ *      fullName: Object<string,string>,
+ *      postScriptName: Object<string,string>,
+ *      designer: Object<string,string>,
+ *      designerURL: Object<string,string>,
+ *      manufacturer: Object<string,string>,
+ *      manufacturerURL: Object<string,string>,
+ *      license: Object<string,string>,
+ *      licenseURL: Object<string,string>,
+ *      version: Object<string,string>,
+ *      description: Object<string,string>,
+ *      copyright: Object<string,string>,
+ *      trademark: Object<string,string>
+ * }}
+ */
 function createDefaultNamesInfo(options) {
     return {
         fontFamily: {en: options.familyName || ' '},
@@ -84,15 +103,43 @@ function Font(options) {
         if (options.descender > 0) throw new Error('When creating a new Font object, negative descender value is required.');
 
         // OS X will complain if the names are empty, so we put a single space everywhere by default.
+        /**
+         * Font name information in multiple languages and platforms.
+         * @type {{unicode: ?NamePlatform, macintosh: ?NamePlatform, windows: ?NamePlatform}}
+         */
         this.names = {};
         this.names.unicode = createDefaultNamesInfo(options);
         this.names.macintosh = createDefaultNamesInfo(options);
         this.names.windows = createDefaultNamesInfo(options);
+        /**
+         * Units per em (the font design grid size).
+         * @type {number}
+         */
         this.unitsPerEm = options.unitsPerEm || 1000;
+        /**
+         * The ascender value of the font.
+         * @type {number}
+         */
         this.ascender = options.ascender;
+        /**
+         * The descender value of the font (typically negative).
+         * @type {number}
+         */
         this.descender = options.descender;
+        /**
+         * Unix timestamp when the font was created.
+         * @type {number}
+         */
         this.createdTimestamp = options.createdTimestamp;
+        /**
+         * The italic angle of the font in degrees.
+         * @type {number}
+         */
         this.italicAngle = options.italicAngle || 0;
+        /**
+         * The weight class of the font (100-900).
+         * @type {number}
+         */
         this.weightClass = options.weightClass || 0;
 
         let selection = 0;
@@ -116,6 +163,10 @@ function Font(options) {
             options.panose = [0, 0, 0, 0, 0, 0, 0, 0, 0];
         }
 
+        /**
+         * Font table objects containing raw table data.
+         * @type {Object}
+         */
         this.tables = Object.assign(options.tables, {
             os2: Object.assign({
                 usWeightClass: options.weightClass || this.usWeightClasses.MEDIUM,
@@ -135,10 +186,30 @@ function Font(options) {
         });
     }
 
+    /**
+     * Indicates if the font is supported. Deprecated - errors are thrown during parsing if font is unsupported.
+     * @type {boolean}
+     */
     this.supported = true; // Deprecated: parseBuffer will throw an error if font is not supported.
+    /**
+     * The set of glyphs in this font.
+     * @type {glyphset.GlyphSet}
+     */
     this.glyphs = new glyphset.GlyphSet(this, options.glyphs || []);
+    /**
+     * Character encoding table for the font.
+     * @type {Object}
+     */
     this.encoding = new DefaultEncoding(this);
+    /**
+     * Glyph positioning information for OpenType layout features.
+     * @type {Object}
+     */
     this.position = new Position(this);
+    /**
+     * Glyph substitution information for OpenType layout features.
+     * @type {Object}
+     */
     this.substitution = new Substitution(this);
     this.tables = this.tables || {};
 
@@ -152,8 +223,27 @@ function Font(options) {
         }
     });
 
+    /**
+     * Variable font variation data, available if the font has variable axes (gvar or cff2 tables).
+     * @type {VariationManager|undefined}
+     * @alias opentype.Font.prototype.variation
+     */
+    this.variation = undefined; // Initialized lazily through Proxy setter above
+
+    /**
+     * Color palette manager for COLR/CPAL color fonts.
+     * @type {Object}
+     */
     this.palettes = new PaletteManager(this);
+    /**
+     * Layer manager for COLR layered color fonts.
+     * @type {Object}
+     */
     this.layers = new LayerManager(this);
+    /**
+     * SVG image manager for SVG table color fonts.
+     * @type {Object}
+     */
     this.svgImages = new SVGImageManager(this);
 
     // needed for low memory mode only.

--- a/src/opentype.mjs
+++ b/src/opentype.mjs
@@ -470,6 +470,10 @@ export {
     Glyph,
     Path,
     BoundingBox,
+    /**
+     * Low-level parse utilities.
+     * @alias opentype._parse
+     */
     parse as _parse,
     parseBuffer as parse,
     load,

--- a/src/parse.mjs
+++ b/src/parse.mjs
@@ -117,44 +117,156 @@ const masks = {
     MAP_ENTRY_SIZE_MASK: 0x30,
 };
 
-// A stateful parser that changes the offset whenever a value is retrieved.
-// The data is a DataView.
+/**
+ * @typedef {Object} LangSysTable
+ * @property {number} reserved
+ * @property {number} reqFeatureIndex
+ * @property {number[]} featureIndexes
+ */
+
+/**
+ * @typedef {Object} LangSysRecord
+ * @property {string} tag
+ * @property {LangSysTable} langSys
+ */
+
+/**
+ * @typedef {Object} ScriptRecord
+ * @property {string} tag
+ * @property {{defaultLangSys?: LangSysTable, langSysRecords: LangSysRecord[]}} script
+ */
+
+/**
+ * @typedef {Object} FeatureRecord
+ * @property {string} tag
+ * @property {{featureParams?: number, lookupListIndexes: number[]}} feature
+ */
+
+/**
+ * @typedef {Object} Lookup
+ * @property {number} lookupType
+ * @property {number} lookupFlag
+ * @property {Array} subtables
+ * @property {number=} markFilteringSet
+ */
+
+/**
+ * @typedef {Object} ItemVariationSubtable
+ * @property {number[]} regionIndexes
+ * @property {number[][]} deltaSets
+ */
+
+/**
+ * @typedef {Object} ItemVariationStore
+ * @property {number} format
+ * @property {Array} variationRegions
+ * @property {ItemVariationSubtable[]} itemVariationSubtables
+ */
+
+/**
+ * @typedef {Object} VariationStore
+ * @property {ItemVariationStore} itemVariationStore
+ */
+
+/**
+ * @typedef {Object} DeltaSetIndexMap
+ * @property {number} format
+ * @property {number} entryFormat
+ * @property {{outerIndex:number,innerIndex:number}[]=} map
+ */
+
+/**
+ * @typedef {Object} TupleVariationHeader
+ * @property {number} variationDataSize
+ * @property {Array<number>=} peakTuple
+ * @property {Array<number>=} intermediateStartTuple
+ * @property {Array<number>=} intermediateEndTuple
+ * @property {Object} flags
+ * @property {number=} sharedTupleRecordsIndex
+ */
+
+
+/**
+ * A stateful parser that changes the offset whenever a value is retrieved.
+ * The data is a DataView.
+ * @constructor
+ * @param {DataView} data
+ * @param {number=} offset
+ */
 function Parser(data, offset) {
     this.data = data;
     this.offset = offset;
     this.relativeOffset = 0;
 }
 
+/**
+ * Parse an unsigned 8-bit integer.
+ * @return {number}
+ */
 Parser.prototype.parseByte = function() {
     const v = this.data.getUint8(this.offset + this.relativeOffset);
     this.relativeOffset += 1;
     return v;
 };
 
+/**
+ * Parse a signed 8-bit integer.
+ * @return {number}
+ */
 Parser.prototype.parseChar = function() {
     const v = this.data.getInt8(this.offset + this.relativeOffset);
     this.relativeOffset += 1;
     return v;
 };
 
+/**
+ * Parse an unsigned 8-bit integer.
+ * @return {number}
+ */
 Parser.prototype.parseCard8 = Parser.prototype.parseByte;
 
+/**
+ * Parse an unsigned 16-bit integer.
+ * @return {number}
+ */
 Parser.prototype.parseUShort = function() {
     const v = this.data.getUint16(this.offset + this.relativeOffset);
     this.relativeOffset += 2;
     return v;
 };
 
+/**
+ * Parse an unsigned 16-bit integer.
+ * @return {number}
+ */
 Parser.prototype.parseCard16 = Parser.prototype.parseUShort;
+
+/**
+ * Parse a string identifier.
+ * @return {number}
+ */
 Parser.prototype.parseSID = Parser.prototype.parseUShort;
+
+/**
+ * Parse an offset16 value.
+ * @return {number}
+ */
 Parser.prototype.parseOffset16 = Parser.prototype.parseUShort;
 
+/**
+ * Parse a signed 16-bit integer.
+ * @return {number}
+ */
 Parser.prototype.parseShort = function() {
     const v = this.data.getInt16(this.offset + this.relativeOffset);
     this.relativeOffset += 2;
     return v;
 };
 
+/**
+ * Parse a 2.14 fixed point number.
+ * @return {number}
+ */
 Parser.prototype.parseF2Dot14 = function() {
     const v = this.data.getInt16(this.offset + this.relativeOffset) / 16384;
     this.relativeOffset += 2;
@@ -162,32 +274,57 @@ Parser.prototype.parseF2Dot14 = function() {
 };
 
 
+/**
+ * Parse a 24-bit unsigned integer.
+ * @return {number}
+ */
 Parser.prototype.parseUInt24 = function() {
     const v = getUInt24(this.data, this.offset + this.relativeOffset);
     this.relativeOffset += 3;
     return v;
 };
 
+/**
+ * Parse a 32-bit unsigned integer.
+ * @return {number}
+ */
 Parser.prototype.parseULong = function() {
     const v = getULong(this.data, this.offset + this.relativeOffset);
     this.relativeOffset += 4;
     return v;
 };
 
+/**
+ * Parse a 32-bit signed integer.
+ * @return {number}
+ */
 Parser.prototype.parseLong = function() {
     const v = getLong(this.data, this.offset + this.relativeOffset);
     this.relativeOffset += 4;
     return v;
 };
 
+/**
+ * Parse a 32-bit unsigned integer offset.
+ * @return {number}
+ */
 Parser.prototype.parseOffset32 = Parser.prototype.parseULong;
 
+/**
+ * Parse a 16.16 fixed point number.
+ * @return {number}
+ */
 Parser.prototype.parseFixed = function() {
     const v = getFixed(this.data, this.offset + this.relativeOffset);
     this.relativeOffset += 4;
     return v;
 };
 
+/**
+ * Parse a string of the given byte length.
+ * @param {number} length
+ * @return {string}
+ */
 Parser.prototype.parseString = function(length) {
     const dataView = this.data;
     const offset = this.offset + this.relativeOffset;
@@ -200,6 +337,10 @@ Parser.prototype.parseString = function(length) {
     return string;
 };
 
+/**
+ * Parse a 4-character tag.
+ * @return {string}
+ */
 Parser.prototype.parseTag = function() {
     return this.parseString(4);
 };
@@ -209,6 +350,10 @@ Parser.prototype.parseTag = function() {
 // only take the last 32 bits.
 // + Since until 2038 those bits will be filled by zeros we can ignore them.
 // FIXME: at some point we need to support dates >2038 using the full 64bit
+/**
+ * Parse a LONGDATETIME (Mac epoch) and convert to Unix seconds.
+ * @return {number}
+ */
 Parser.prototype.parseLongDateTime = function() {
     let v = getULong(this.data, this.offset + this.relativeOffset + 4);
     // Subtract seconds between 01/01/1904 and 01/01/1970
@@ -218,6 +363,11 @@ Parser.prototype.parseLongDateTime = function() {
     return v;
 };
 
+/**
+ * Parse a fixed-point version number.
+ * @param {number=} minorBase
+ * @return {number}
+ */
 Parser.prototype.parseVersion = function(minorBase) {
     const major = getUShort(this.data, this.offset + this.relativeOffset);
 
@@ -230,6 +380,12 @@ Parser.prototype.parseVersion = function(minorBase) {
     return major + minor / minorBase / 10;
 };
 
+/**
+ * Skip a number of items of the given type.
+ * @param {string} type
+ * @param {number=} amount
+ * @return {undefined}
+ */
 Parser.prototype.skip = function(type, amount) {
     if (amount === undefined) {
         amount = 1;
@@ -241,6 +397,11 @@ Parser.prototype.skip = function(type, amount) {
 ///// Parsing lists and records ///////////////////////////////
 
 // Parse a list of 32 bit unsigned integers.
+/**
+ * Parse a list of 32-bit unsigned integers.
+ * @param {number=} count
+ * @return {number[]}
+ */
 Parser.prototype.parseULongList = function(count) {
     if (count === undefined) { count = this.parseULong(); }
     const offsets = new Array(count);
@@ -257,8 +418,17 @@ Parser.prototype.parseULongList = function(count) {
 
 // Parse a list of 16 bit unsigned integers. The length of the list can be read on the stream
 // or provided as an argument.
-Parser.prototype.parseOffset16List =
-Parser.prototype.parseUShortList = function(count) {
+/**
+ * Parse a list of 16-bit unsigned integers.
+ * @param {number=} count
+ * @return {number[]}
+ */
+/**
+ * Parse a list of 16-bit unsigned integers.
+ * @param {number=} count
+ * @return {number[]}
+ */
+Parser.prototype.parseOffset16List = function(count) {
     if (count === undefined) { count = this.parseUShort(); }
     const offsets = new Array(count);
     const dataView = this.data;
@@ -272,7 +442,19 @@ Parser.prototype.parseUShortList = function(count) {
     return offsets;
 };
 
+/**
+ * Parse a list of 16-bit unsigned integers.
+ * @param {number=} count
+ * @return {number[]}
+ */
+Parser.prototype.parseUShortList = Parser.prototype.parseOffset16List;
+
 // Parses a list of 16 bit signed integers.
+/**
+ * Parse a list of 16-bit signed integers.
+ * @param {number} count
+ * @return {number[]}
+ */
 Parser.prototype.parseShortList = function(count) {
     const list = new Array(count);
     const dataView = this.data;
@@ -287,6 +469,11 @@ Parser.prototype.parseShortList = function(count) {
 };
 
 // Parses a list of bytes.
+/**
+ * Parse a list of bytes.
+ * @param {number} count
+ * @return {number[]}
+ */
 Parser.prototype.parseByteList = function(count) {
     const list = new Array(count);
     const dataView = this.data;
@@ -303,6 +490,10 @@ Parser.prototype.parseByteList = function(count) {
  * Parse a list of items.
  * Record count is optional, if omitted it is read from the stream.
  * itemCallback is one of the Parser methods.
+ * @template T
+ * @param {number|function()} [count]
+ * @param {function():T} [itemCallback]
+ * @return {Array<T>}
  */
 Parser.prototype.parseList = function(count, itemCallback) {
     if (!itemCallback) {
@@ -316,6 +507,13 @@ Parser.prototype.parseList = function(count, itemCallback) {
     return list;
 };
 
+/**
+ * Parse a list of items using a 32-bit count.
+ * @template T
+ * @param {number|function()} [count]
+ * @param {function():T} [itemCallback]
+ * @return {Array<T>}
+ */
 Parser.prototype.parseList32 = function(count, itemCallback) {
     if (!itemCallback) {
         itemCallback = count;
@@ -332,6 +530,9 @@ Parser.prototype.parseList32 = function(count, itemCallback) {
  * Parse a list of records.
  * Record count is optional, if omitted it is read from the stream.
  * Example of recordDescription: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
+ * @param {number|Object} [count]
+ * @param {Object} [recordDescription]
+ * @return {Array<Object>}
  */
 Parser.prototype.parseRecordList = function(count, recordDescription) {
     // If the count argument is absent, read it in the stream.
@@ -353,6 +554,12 @@ Parser.prototype.parseRecordList = function(count, recordDescription) {
     return records;
 };
 
+/**
+ * Parse a list of records using a 32-bit count.
+ * @param {number|Object} [count]
+ * @param {Object} [recordDescription]
+ * @return {Array<Object>}
+ */
 Parser.prototype.parseRecordList32 = function(count, recordDescription) {
     // If the count argument is absent, read it in the stream.
     if (!recordDescription) {
@@ -373,6 +580,12 @@ Parser.prototype.parseRecordList32 = function(count, recordDescription) {
     return records;
 };
 
+/**
+ * Parse N tuples of F2.14 values.
+ * @param {number} tupleCount
+ * @param {number} axisCount
+ * @return {Array<Array<number>>}
+ */
 Parser.prototype.parseTupleRecords = function(tupleCount, axisCount) {
     let tuples = [];
     for (let i = 0; i < tupleCount; i++) {
@@ -385,8 +598,12 @@ Parser.prototype.parseTupleRecords = function(tupleCount, axisCount) {
     return tuples;
 };
 
-// Parse a data structure into an object
-// Example of description: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
+/**
+ * Parse a data structure into an object.
+ * Example of description: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
+ * @param {Object|function()} description
+ * @return {Object}
+ */
 Parser.prototype.parseStruct = function(description) {
     if (typeof description === 'function') {
         return description.call(this);
@@ -406,6 +623,8 @@ Parser.prototype.parseStruct = function(description) {
  * Parse a GPOS valueRecord
  * https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#value-record
  * valueFormat is optional, if omitted it is read from the stream.
+ * @param {number=} valueFormat
+ * @return {Object|undefined}
  */
 Parser.prototype.parseValueRecord = function(valueFormat) {
     if (valueFormat === undefined) {
@@ -448,6 +667,11 @@ Parser.prototype.parseValueRecordList = function() {
     return values;
 };
 
+/**
+ * Parse a pointer to another offset-based structure.
+ * @param {Object|function()} description
+ * @return {Object|undefined}
+ */
 Parser.prototype.parsePointer = function(description) {
     const structOffset = this.parseOffset16();
     if (structOffset > 0) {
@@ -457,6 +681,11 @@ Parser.prototype.parsePointer = function(description) {
     return undefined;
 };
 
+/**
+ * Parse a 32-bit pointer to another offset-based structure.
+ * @param {Object|function()} description
+ * @return {Object|undefined}
+ */
 Parser.prototype.parsePointer32 = function(description) {
     const structOffset = this.parseOffset32();
     if (structOffset > 0) {
@@ -472,6 +701,13 @@ Parser.prototype.parsePointer32 = function(description) {
  * If itemCallback is not provided, a list of list of UShort is assumed.
  * If provided, itemCallback is called on each item and must parse the item.
  * See examples in tables/gsub.mjs
+ */
+/**
+ * Parse a list of lists of values from the stream.
+ * If no itemCallback is provided, it parses a list of UShort lists.
+ * @template T
+ * @param {function():T} [itemCallback]
+ * @return {Array<T|undefined>}
  */
 Parser.prototype.parseListOfLists = function(itemCallback) {
     const offsets = this.parseOffset16List();
@@ -503,11 +739,10 @@ Parser.prototype.parseListOfLists = function(itemCallback) {
     return list;
 };
 
-///// Complex tables parsing //////////////////////////////////
-
-// Parse a coverage table in a GSUB, GPOS or GDEF table.
-// https://www.microsoft.com/typography/OTSPEC/chapter2.htm
-// parser.offset must point to the start of the table containing the coverage.
+/**
+ * Parse a coverage table in a GSUB, GPOS or GDEF table.
+ * @return {Object}
+ */
 Parser.prototype.parseCoverage = function() {
     const startOffset = this.offset + this.relativeOffset;
     const format = this.parseUShort();
@@ -534,8 +769,10 @@ Parser.prototype.parseCoverage = function() {
     throw new Error('0x' + startOffset.toString(16) + ': Coverage format must be 1 or 2.');
 };
 
-// Parse a Class Definition Table in a GSUB, GPOS or GDEF table.
-// https://www.microsoft.com/typography/OTSPEC/chapter2.htm
+/**
+ * Parse a class definition table in a GSUB, GPOS or GDEF table.
+ * @return {Object}
+ */
 Parser.prototype.parseClassDef = function() {
     const startOffset = this.offset + this.relativeOffset;
     const format = this.parseUShort();
@@ -601,17 +838,91 @@ Parser.pointer32 = function(description) {
     };
 };
 
+/**
+ * Parse a 4-character tag.
+ * @return {string}
+ */
 Parser.tag = Parser.prototype.parseTag;
+
+/**
+ * Parse an unsigned 8-bit integer.
+ * @return {number}
+ */
 Parser.byte = Parser.prototype.parseByte;
-Parser.uShort = Parser.offset16 = Parser.prototype.parseUShort;
+
+/**
+ * Parse an unsigned 16-bit integer.
+ * @return {number}
+ */
+Parser.uShort = Parser.prototype.parseUShort;
+
+/**
+ * Parse an offset16 value.
+ * @return {number}
+ */
+Parser.offset16 = Parser.prototype.parseUShort;
+
+/**
+ * Parse a list of 16-bit unsigned integers.
+ * @param {number=} count
+ * @return {number[]}
+ */
 Parser.uShortList = Parser.prototype.parseUShortList;
+
+/**
+ * Parse a 24-bit unsigned integer.
+ * @return {number}
+ */
 Parser.uInt24 = Parser.prototype.parseUInt24;
-Parser.uLong = Parser.offset32 = Parser.prototype.parseULong;
+
+/**
+ * Parse a 32-bit unsigned integer.
+ * @return {number}
+ */
+Parser.uLong = Parser.prototype.parseULong;
+
+/**
+ * Parse a 32-bit unsigned integer offset.
+ * @return {number}
+ */
+Parser.offset32 = Parser.prototype.parseULong;
+
+/**
+ * Parse a list of 32-bit unsigned integers.
+ * @param {number=} count
+ * @return {number[]}
+ */
 Parser.uLongList = Parser.prototype.parseULongList;
+
+/**
+ * Parse a 16.16 fixed point number.
+ * @return {number}
+ */
 Parser.fixed = Parser.prototype.parseFixed;
+
+/**
+ * Parse a 2.14 fixed point number.
+ * @return {number}
+ */
 Parser.f2Dot14 = Parser.prototype.parseF2Dot14;
+
+/**
+ * Parse a structure based on a description or callback.
+ * @param {Object|function()} description
+ * @return {Object}
+ */
 Parser.struct = Parser.prototype.parseStruct;
+
+/**
+ * Parse a coverage table.
+ * @return {Object}
+ */
 Parser.coverage = Parser.prototype.parseCoverage;
+
+/**
+ * Parse a class definition table.
+ * @return {Object}
+ */
 Parser.classDef = Parser.prototype.parseClassDef;
 
 ///// Script, Feature, Lookup lists ///////////////////////////////////////////////
@@ -623,6 +934,10 @@ const langSysTable = {
     featureIndexes: Parser.uShortList
 };
 
+/**
+ * Parse a ScriptList and return an array of `ScriptRecord`.
+ * @return {ScriptRecord[]}
+ */
 Parser.prototype.parseScriptList = function() {
     return this.parsePointer(Parser.recordList({
         tag: Parser.tag,
@@ -636,6 +951,10 @@ Parser.prototype.parseScriptList = function() {
     })) || [];
 };
 
+/**
+ * Parse a FeatureList and return an array of `FeatureRecord`.
+ * @return {FeatureRecord[]}
+ */
 Parser.prototype.parseFeatureList = function() {
     return this.parsePointer(Parser.recordList({
         tag: Parser.tag,
@@ -646,6 +965,11 @@ Parser.prototype.parseFeatureList = function() {
     })) || [];
 };
 
+/**
+ * Parse a LookupList using provided parsers and return an array of `Lookup` objects.
+ * @param {Object} lookupTableParsers - map of lookupType to parser function
+ * @return {Lookup[]}
+ */
 Parser.prototype.parseLookupList = function(lookupTableParsers) {
     return this.parsePointer(Parser.list(Parser.pointer(function() {
         const lookupType = this.parseUShort();
@@ -661,6 +985,10 @@ Parser.prototype.parseLookupList = function(lookupTableParsers) {
     }))) || [];
 };
 
+/**
+ * Parse a FeatureVariationsList.
+ * @return {Object[]}
+ */
 Parser.prototype.parseFeatureVariationsList = function() {
     return this.parsePointer32(function() {
         const majorVersion = this.parseUShort();
@@ -678,6 +1006,10 @@ Parser.prototype.parseFeatureVariationsList = function() {
 // https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats
 // https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables
 
+/**
+ * Parse a VariationStore structure.
+ * @return {VariationStore}
+ */
 Parser.prototype.parseVariationStore = function() {
     const vsOffset = this.relativeOffset;
     const length = this.parseUShort();
@@ -688,6 +1020,10 @@ Parser.prototype.parseVariationStore = function() {
     return variationStore;
 };
 
+/**
+ * Parse an ItemVariationStore.
+ * @return {ItemVariationStore}
+ */
 Parser.prototype.parseItemVariationStore = function() {
     const itemStoreOffset = this.relativeOffset;
     const iVStore = {
@@ -712,6 +1048,10 @@ Parser.prototype.parseItemVariationStore = function() {
     return iVStore;
 };
 
+/**
+ * Parse a VariationRegionList.
+ * @return {Array<Object>}
+ */
 Parser.prototype.parseVariationRegionList = function() {
     const axisCount = this.parseUShort();
     const regionCount = this.parseUShort();
@@ -724,6 +1064,10 @@ Parser.prototype.parseVariationRegionList = function() {
     });
 };
 
+/**
+ * Parse an ItemVariationSubtable.
+ * @return {ItemVariationSubtable}
+ */
 Parser.prototype.parseItemVariationSubtable = function() {
     const itemCount = this.parseUShort();
     const wordDeltaCount = this.parseUShort();
@@ -739,6 +1083,10 @@ Parser.prototype.parseItemVariationSubtable = function() {
     return subtable;
 };
 
+/**
+ * Parse a DeltaSetIndexMap.
+ * @return {DeltaSetIndexMap}
+ */
 Parser.prototype.parseDeltaSetIndexMap = function() {
     const format = this.parseByte();
     const entryFormat = this.parseByte();
@@ -790,6 +1138,13 @@ Parser.prototype.parseDeltaSetIndexMap = function() {
     };
 };
 
+/**
+ * Parse delta sets for item variation subtables.
+ * @param {number} itemCount
+ * @param {number} wordDeltaCount
+ * @param {number} regionIndexCount
+ * @return {number[][]}
+ */
 Parser.prototype.parseDeltaSets = function(itemCount, wordDeltaCount, regionIndexCount) {
     const deltas = Array.from({length: itemCount},()=>[]); // two-dimensional array with empty rows and columns
 
@@ -816,6 +1171,13 @@ Parser.prototype.parseDeltaSets = function(itemCount, wordDeltaCount, regionInde
     return deltas;
 };
 
+/**
+ * Parse a TupleVariationStoreList and return a glyph-indexed map of variation stores.
+ * @param {number} axisCount
+ * @param {string} flavor
+ * @param {Map<number, Object>|Array} glyphs
+ * @return {Object.<number, (Object|undefined)>}
+ */
 Parser.prototype.parseTupleVariationStoreList = function(axisCount, flavor, glyphs) {
     const glyphCount = this.parseUShort();
     const flags = this.parseUShort();
@@ -852,6 +1214,15 @@ Parser.prototype.parseTupleVariationStoreList = function(axisCount, flavor, glyp
     return glyphVariations;
 };
 
+/**
+ * Parse a TupleVariationStore at the given offset.
+ * @param {number} tableOffset
+ * @param {number} axisCount
+ * @param {string} flavor
+ * @param {Map<number, Object>|Array} glyphs
+ * @param {number} glyphIndex
+ * @return {Object}
+ */
 Parser.prototype.parseTupleVariationStore = function(tableOffset, axisCount, flavor, glyphs, glyphIndex) {
     const relativeOffset = this.relativeOffset;
     
@@ -971,6 +1342,12 @@ Parser.prototype.parseTupleVariationStore = function(tableOffset, axisCount, fla
     return result;
 };
 
+/**
+ * Parse a TupleVariationHeader.
+ * @param {number} axisCount
+ * @param {string} flavor
+ * @return {TupleVariationHeader}
+ */
 Parser.prototype.parseTupleVariationHeader = function(axisCount, flavor) {
     const variationDataSize = this.parseUShort();
     const tupleIndex = this.parseUShort();
@@ -1004,6 +1381,10 @@ Parser.prototype.parseTupleVariationHeader = function(axisCount, flavor) {
     return result;
 };
 
+/**
+ * Parse packed point numbers and return an array of point indices.
+ * @return {number[]}
+ */
 Parser.prototype.parsePackedPointNumbers = function() {
     const countByte1 = this.parseByte();
     const points = [];
@@ -1040,6 +1421,11 @@ Parser.prototype.parsePackedPointNumbers = function() {
     return points;
 };
 
+/**
+ * Parse packed delta values and return an array of deltas.
+ * @param {number} expectedCount
+ * @return {number[]}
+ */
 Parser.prototype.parsePackedDeltas = function(expectedCount) {
     const deltas = [];
     
@@ -1064,18 +1450,110 @@ Parser.prototype.parsePackedDeltas = function(expectedCount) {
 };
 
 export default {
+    /**
+     * Parse an unsigned 8-bit integer.
+     * @alias opentype._parse.getByte
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
     getByte,
+    /**
+     * Parse an unsigned 8-bit integer.
+     * @alias opentype._parse.getCard8
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
     getCard8: getByte,
+    /**
+     * Parse an unsigned 16-bit integer.
+     * @alias opentype._parse.getUShort
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
     getUShort,
+    /**
+     * Parse an unsigned 16-bit integer.
+     * @alias opentype._parse.getCard16
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
     getCard16: getUShort,
+    /**
+     * Parse a signed 16-bit integer.
+     * @alias opentype._parse.getShort
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
     getShort,
+    /**
+     * Parse a 24-bit unsigned integer.
+     * @alias opentype._parse.getUInt24
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
     getUInt24,
+    /**
+     * Parse a 32-bit unsigned integer.
+     * @alias opentype._parse.getULong
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
     getULong,
+    /**
+     * Parse a 16.16 fixed point number.
+     * @alias opentype._parse.getFixed
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {number}
+     */
     getFixed,
+    /**
+     * Parse a 4-character tag.
+     * @alias opentype._parse.getTag
+     * @param {DataView} data
+     * @param {number} offset
+     * @return {string}
+     */
     getTag,
+    /**
+     * Parse an offset from the DataView.
+     * @alias opentype._parse.getOffset
+     * @param {DataView} data
+     * @param {number} offset
+     * @param {number} offSize
+     * @return {number}
+     */
     getOffset,
+    /**
+     * Retrieve a number of bytes from start offset to the end offset.
+     * @alias opentype._parse.getBytes
+     * @param {DataView} dataView
+     * @param {number} startOffset
+     * @param {number} endOffset
+     * @return {number[]}
+     */
     getBytes,
+    /**
+     * Convert bytes to a string.
+     * @alias opentype._parse.bytesToString
+     * @param {number[]} bytes
+     * @return {string}
+     */
     bytesToString,
+    /**
+     * Parser constructor.
+     * @alias opentype._parse.Parser
+     * @constructor
+     * @param {DataView} data
+     * @param {number=} offset
+     */
     Parser,
 };
 

--- a/src/parse.mjs
+++ b/src/parse.mjs
@@ -194,8 +194,20 @@ const masks = {
  * @param {number=} offset
  */
 function Parser(data, offset) {
+    /**
+     * The binary data to parse.
+     * @type {DataView}
+     */
     this.data = data;
+    /**
+     * The current absolute offset in the data.
+     * @type {number}
+     */
     this.offset = offset;
+    /**
+     * Offset relative to the current offset, used for reading nested structures.
+     * @type {number}
+     */
     this.relativeOffset = 0;
 }
 

--- a/src/path.mjs
+++ b/src/path.mjs
@@ -374,16 +374,16 @@ Path.prototype.lineTo = function(x, y) {
 
 /**
  * Draws cubic curve
- * @function
- * bezierCurveTo
+ * @function curveTo
  * @memberof opentype.Path.prototype
+ * @alias opentype.Path.prototype.bezierCurveTo
  * @param  {number} x1 - x of control 1
  * @param  {number} y1 - y of control 1
  * @param  {number} x2 - x of control 2
  * @param  {number} y2 - y of control 2
  * @param  {number} x - x of path point
  * @param  {number} y - y of path point
- * @see curveTo
+ * @see bezierCurveTo
  */
 Path.prototype.curveTo = Path.prototype.bezierCurveTo = function(x1, y1, x2, y2, x, y) {
     this.commands.push({
@@ -399,20 +399,9 @@ Path.prototype.curveTo = Path.prototype.bezierCurveTo = function(x1, y1, x2, y2,
 
 /**
  * Draws quadratic curve
- * @function
- * quadraticCurveTo
+ * @function quadTo
  * @memberof opentype.Path.prototype
- * @param  {number} x1 - x of control
- * @param  {number} y1 - y of control
- * @param  {number} x - x of path point
- * @param  {number} y - y of path point
- */
-
-/**
- * Draws quadratic curve
- * @function
- * quadTo
- * @memberof opentype.Path.prototype
+ * @alias opentype.Path.prototype.quadraticCurveTo
  * @param  {number} x1 - x of control
  * @param  {number} y1 - y of control
  * @param  {number} x - x of path point

--- a/src/path.mjs
+++ b/src/path.mjs
@@ -10,9 +10,29 @@ import BoundingBox from './bbox.mjs';
  * @constructor
  */
 function Path() {
+    /**
+     * The list of drawing commands for the path.
+     * @type {Array<Object>}
+     * @alias opentype.Path.prototype.commands
+     */
     this.commands = [];
+    /**
+     * Fill color for the path. If null, the path is not filled.
+     * @type {string|null}
+     * @alias opentype.Path.prototype.fill
+     */
     this.fill = 'black';
+    /**
+     * Stroke color for the path. If null, the path is not stroked.
+     * @type {string|null}
+     * @alias opentype.Path.prototype.stroke
+     */
     this.stroke = null;
+    /**
+     * Stroke width for the path outline.
+     * @type {number}
+     * @alias opentype.Path.prototype.strokeWidth
+     */
     this.strokeWidth = 1;
     // the _layer property is only set on computed paths during glyph rendering
     // this._layers = [];


### PR DESCRIPTION
Added a utility to automatically generate types for closure compiler.

## Description
This adds `scripts/externs-generator.js` to generate externs for the closure compiler.

## Motivation and Context
Our closure compiler externs are outdated and it is difficult to keep them updated, so let's automate it.

## How Has This Been Tested?
I verified the output matches the source code.

**This PR was mostly AI generated, I plan to rework and revise the code manually before merging to improve it.** I didn't use AI to change code in src. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **Contribute** README section.
