### PR TITLE
fix: decode 16.16 Fixed with /65536 instead of /65535

### DIFF
--- a/src/parse.mjs
+++ b/src/parse.mjs
@@ -41,7 +41,7 @@ function getLong(dataView, offset) {
 function getFixed(dataView, offset) {
     const decimal = dataView.getInt16(offset, false);
     const fraction = dataView.getUint16(offset + 2, false);
-    return decimal + fraction / 65535;
+    return decimal + fraction / 65536;
 }
 
 // Retrieve a 4-character tag from the DataView.

--- a/test/tables/stat.spec.mjs
+++ b/test/tables/stat.spec.mjs
@@ -36,9 +36,9 @@ describe('tables/stat.mjs', function() {
             { tag: 'opsz', nameID: 72, ordering: 2 }
         ],
         values: [
-            { format: 1, axisIndex: 1, flags: 2, valueNameID: 120, value: 291.2711070420386 },
+            { format: 1, axisIndex: 1, flags: 2, valueNameID: 120, value: 291.27110290527344 },
             { format: 2, axisIndex: 2, flags: 1, valueNameID: 150, nominalValue: 24, rangeMinValue: 2, rangeMaxValue: 32767 },
-            { format: 3, axisIndex: 1, flags: 2, valueNameID: 252, value: 1.1367208361944, linkedValue: 69.40444037537193 },
+            { format: 3, axisIndex: 1, flags: 2, valueNameID: 252, value: 1.13671875, linkedValue: 69.40443420410156 },
             { format: 4, flags: 1, valueNameID: 328, axisValues: [
                 { axisIndex: 2, value: -32768 },
                 { axisIndex: 0, value: 420 }


### PR DESCRIPTION
`getFixed` (`src/parse.mjs`) decodes a 16.16 `Fixed` value's fractional part with `/ 65535`:

```js
function getFixed(dataView, offset) {
    const decimal = dataView.getInt16(offset, false);
    const fraction = dataView.getUint16(offset + 2, false);
    return decimal + fraction / 65535;   // should be / 65536
}
```

Per the OpenType *Data Types* spec, `Fixed` is a "32-bit signed fixed-point number (16.16)" — the 16-bit fraction is a binary fraction over **2^16 = 65536**, not 65535. The sibling `parseF2Dot14` in the same file correctly divides by `16384 = 2^14`, which isolates this as an off-by-one in `getFixed`.

### Effect
`getFixed` backs `post.italicAngle`, `head.fontRevision`, the `fvar` axis min/default/max + instance coordinates, and the `STAT` table values. They are all off by up to `1/65536` (~1.5e-5), and they do **not round-trip**: the encode path scales by `65536` (`src/types.mjs`, `src/tables/post.mjs`, `src/tables/fvar.mjs`), so `parse → write → parse` drifts.

Concrete real fonts (macOS system fonts):

| Font | `post.italicAngle` (current) | correct (`/65536`) |
|---|---|---|
| Arial Narrow Italic | `-9.699992370489051` | `-9.699996948242188` |
| Times New Roman Italic | `-16.332982375829708` | `-16.332992553710938` |

The magnitude is small — it does not cross a glyph-metric/rendering threshold — so this is a spec-conformance / round-trip-consistency fix, not a rendering change.

### Fix
`getFixed`: `/ 65535` → `/ 65536`. The two `STAT` parse fixtures (`test/tables/stat.spec.mjs`) asserted the old `/65535` values (e.g. raw Fixed `01 23 45 67` = `291 + 17767/65535 = 291.2711070…`); updated to the spec value `291 + 17767/65536 = 291.2711029…`. They fail on the current code and pass with the fix; the full suite (342) and lint are green.
