### PR TITLE
fix(cmap): clamp format 12/13 character codes to the Unicode maximum

### DIFF
--- a/src/tables/cmap.mjs
+++ b/src/tables/cmap.mjs
@@ -36,12 +36,19 @@ function parseCmapTableFormat12or13(cmap, p, format) {
     cmap.groupCount = groupCount = p.parseULong();
     cmap.glyphIndexMap = {};
 
+    // Character codes in a format 12/13 subtable are Unicode code points, which
+    // never exceed U+10FFFF. Clamp each group to that range so a malformed group
+    // with an out-of-range endCharCode can neither map invalid code points nor
+    // spin the loop for billions of iterations. Format 4 is implicitly bounded
+    // by its 16-bit fields; this keeps 12/13 in line.
+    const unicodeMax = 0x10FFFF;
     for (let i = 0; i < groupCount; i += 1) {
         const startCharCode = p.parseULong();
         const endCharCode = p.parseULong();
         let startGlyphId = p.parseULong();
 
-        for (let c = startCharCode; c <= endCharCode; c += 1) {
+        const lastCharCode = endCharCode > unicodeMax ? unicodeMax : endCharCode;
+        for (let c = startCharCode; c <= lastCharCode; c += 1) {
             cmap.glyphIndexMap[c] = startGlyphId;
             if (format === 12) {
                 startGlyphId++;

--- a/test/tables/cmap.spec.mjs
+++ b/test/tables/cmap.spec.mjs
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { unhex } from '../testutil.mjs';
 import { Parser } from '../../src/parse.mjs';
 import { parseCmapTableFormat14, parseCmapTableFormat0, makeCmapTable } from '../../src/tables/cmap.mjs';
+import cmapTable from '../../src/tables/cmap.mjs';
 import { Font, Path, Glyph, parse } from '../../src/opentype.mjs';
 import { readFileSync } from 'fs';
 const loadSync = (url, opt) => parse(readFileSync(url), opt);
@@ -81,6 +82,25 @@ describe('tables/cmap.mjs', function() {
         const glyphIds = font.stringToGlyphIndexes(testString);
         const expectedGlyphIds = [1,2,3,4];
         assert.deepEqual(glyphIds, expectedGlyphIds);
+    });
+
+    it('does not map format 12 code points beyond U+10FFFF', function() {
+        // A single format 12 group whose range straddles the Unicode maximum.
+        const cmapData =
+            '0000 0001' +              // version, numTables
+            '0003 000A 0000000C' +     // platformID 3, encodingID 10, offset 12
+            '000C 0000' +              // format 12, reserved
+            '00000000' +               // length (unused on this path)
+            '00000000' +               // language
+            '00000001' +               // numGroups
+            '0010FFFE 00110003 00000005'; // startCharCode, endCharCode, startGlyphId
+        const cmap = cmapTable.parse(unhex(cmapData), 0);
+        assert.equal(cmap.glyphIndexMap[0x10FFFE], 5);
+        assert.equal(cmap.glyphIndexMap[0x10FFFF], 6);
+        // Code points above U+10FFFF must not be mapped.
+        assert.equal(cmap.glyphIndexMap[0x110000], undefined);
+        assert.equal(cmap.glyphIndexMap[0x110003], undefined);
+        assert.equal(Object.keys(cmap.glyphIndexMap).length, 2);
     });
 
     // Helper: create a mock GlyphSet for makeCmapTable


### PR DESCRIPTION
The format 12 and 13 cmap parsers expand each group with a `for (c = startCharCode; c <= endCharCode; c++)` loop but never bound the character code. Both `startCharCode` and `endCharCode` are 32-bit values read straight from the font, while character codes in these subtables are Unicode code points and so cannot exceed U+10FFFF.

For a malformed group this has two effects:

- Code points above U+10FFFF are added to `glyphIndexMap`. They can never be looked up and are out of range per the spec.
- A group with a large `endCharCode` makes the loop run up to ~4.3 billion times from a single 12-byte record. I measured ~1.4s and 67M map entries for `endCharCode = 0x4000000`, and it scales linearly, so a corrupt `0xFFFFFFFF` ends up hanging the parse and exhausting memory.

The format 4 parser doesn't hit this because its `startCount`/`endCount` are 16-bit, so its loop is implicitly capped at U+FFFF. This change clamps each format 12/13 group's upper bound to U+10FFFF so 12/13 behave the same way. Valid fonts are unaffected since real code points are always in range.

The added test uses a single group that straddles the boundary (U+10FFFE..U+110003): the two in-range code points map and the out-of-range ones don't. Reverting the clamp makes it fail. `mocha test/tables/cmap.spec.mjs` passes (11 tests) and `eslint src` is clean.

This follows the same malformed-font hardening as #826 and #827.
