### PR TITLE
Support GSUB type 6 format 2 with nested single substitutions

### DIFF
--- a/src/features/applySubstitution.mjs
+++ b/src/features/applySubstitution.mjs
@@ -21,6 +21,22 @@ function singleSubstitutionFormat2(action, tokens, index) {
 }
 
 /**
+ * Apply chaining context substitution format 2.
+ * @param {Array} substitutions substitutions
+ * @param {any} tokens a list of tokens
+ * @param {number} index token index
+ */
+function chainingSubstitutionFormat2(action, tokens, index) {
+    for (let i = 0; i < action.substitution.length; i++) {
+        const substitution = action.substitution[i];
+        tokens[index + substitution.sequenceIndex].setState(
+            action.tag,
+            substitution.substitution
+        );
+    }
+}
+
+/**
  * Apply chaining context substitution format 3
  * @param {Array} substitutions substitutions
  * @param {any} tokens a list of tokens
@@ -65,6 +81,7 @@ function ligatureSubstitutionFormat1(action, tokens, index) {
 const SUBSTITUTIONS = {
     11: singleSubstitutionFormat1,
     12: singleSubstitutionFormat2,
+    62: chainingSubstitutionFormat2,
     63: chainingSubstitutionFormat3,
     41: ligatureSubstitutionFormat1,
     51: chainingSubstitutionFormat3,

--- a/src/features/featureQuery.mjs
+++ b/src/features/featureQuery.mjs
@@ -101,6 +101,145 @@ function lookupCoverageList(coverageList, contextParams) {
 }
 
 /**
+ * Get a single glyph index from a substitution value.
+ * @param {number|number[]} value glyph index or multiple-substitution value
+ * @returns {number} glyph index
+ */
+function getGlyphIndex(value) {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Match glyphs against a sequence of classes.
+ * @param {Font} font font containing the substitution layout helper
+ * @param {any[]} context glyph context
+ * @param {number[]} classes expected glyph classes
+ * @param {any} classDef class definition table
+ * @returns {boolean} whether every class matches
+ */
+function matchGlyphClasses(font, context, classes, classDef) {
+    if (context.length < classes.length) return false;
+    for (let i = 0; i < classes.length; i++) {
+        const glyphClass = font.substitution.getGlyphClass(
+            classDef,
+            getGlyphIndex(context[i])
+        );
+        if (glyphClass !== classes[i]) return false;
+    }
+    return true;
+}
+
+/**
+ * Apply a class chaining rule's nested single-substitution lookups.
+ * @param {ContextParams} contextParams context params to lookup
+ * @param {any} rule matched chaining class rule
+ * @returns {any[]} substitutions with their input sequence indexes
+ */
+function applyChainingLookupRecords(contextParams, rule) {
+    const input = [getGlyphIndex(contextParams.current)];
+    for (let i = 0; i < rule.input.length; i++) {
+        input.push(getGlyphIndex(contextParams.lookahead[i]));
+    }
+
+    const substitutions = [];
+    for (let i = 0; i < rule.lookupRecords.length; i++) {
+        const lookupRecord = rule.lookupRecords[i];
+        const lookupTable = this.getLookupByIndex(
+            lookupRecord.lookupListIndex
+        );
+        for (let s = 0; s < lookupTable.subtables.length; s++) {
+            let lookupSubtable = lookupTable.subtables[s];
+            let substitutionType = this.getSubstitutionType(
+                lookupTable,
+                lookupSubtable
+            );
+            let lookup;
+
+            if (substitutionType === '71') {
+                substitutionType = this.getSubstitutionType(
+                    lookupSubtable,
+                    lookupSubtable.extension
+                );
+                lookup = this.getLookupMethod(
+                    lookupSubtable,
+                    lookupSubtable.extension
+                );
+                lookupSubtable = lookupSubtable.extension;
+            } else {
+                lookup = this.getLookupMethod(lookupTable, lookupSubtable);
+            }
+
+            if (substitutionType !== '11' && substitutionType !== '12') {
+                throw new Error(
+                    `Substitution type ${substitutionType} ` +
+                    'is not supported in chaining substitution'
+                );
+            }
+
+            const sequenceIndex = lookupRecord.sequenceIndex;
+            const substitution = lookup(
+                getGlyphIndex(input[sequenceIndex])
+            );
+            if (substitution !== null && substitution !== undefined) {
+                input[sequenceIndex] = substitution;
+                substitutions.push({ sequenceIndex, substitution });
+                break;
+            }
+        }
+    }
+    return substitutions;
+}
+
+/**
+ * Handle chaining context substitution - format 2.
+ * @param {ContextParams} contextParams context params to lookup
+ * @param {any} subtable chaining context subtable
+ * @returns {{matched: boolean, substitutions: any[]}} lookup result
+ */
+function chainingSubstitutionFormat2(contextParams, subtable) {
+    const glyphIndex = getGlyphIndex(contextParams.current);
+    if (lookupCoverage(glyphIndex, subtable.coverage) === -1) {
+        return { matched: false, substitutions: [] };
+    }
+
+    const inputClass = this.font.substitution.getGlyphClass(
+        subtable.inputClassDef,
+        glyphIndex
+    );
+    const chainClassSet = subtable.chainClassSet[inputClass];
+    if (!chainClassSet) return { matched: false, substitutions: [] };
+
+    const backtrack = contextParams.backtrack.slice().reverse();
+    for (let i = 0; i < chainClassSet.length; i++) {
+        const rule = chainClassSet[i];
+        if (!matchGlyphClasses(
+            this.font,
+            backtrack,
+            rule.backtrack,
+            subtable.backtrackClassDef
+        )) continue;
+        if (!matchGlyphClasses(
+            this.font,
+            contextParams.lookahead,
+            rule.input,
+            subtable.inputClassDef
+        )) continue;
+        if (!matchGlyphClasses(
+            this.font,
+            contextParams.lookahead.slice(rule.input.length),
+            rule.lookahead,
+            subtable.lookaheadClassDef
+        )) continue;
+
+        const substitutions = rule.lookupRecords.length ?
+            applyChainingLookupRecords.call(this, contextParams, rule) :
+            [];
+        return { matched: true, substitutions };
+    }
+    return { matched: false, substitutions: [] };
+}
+
+/**
  * Handle chaining context substitution - format 3
  * @param {ContextParams} contextParams context params to lookup
  */
@@ -413,6 +552,10 @@ FeatureQuery.prototype.getLookupMethod = function(lookupTable, subtable) {
             return glyphIndex => singleSubstitutionFormat2.apply(
                 this, [glyphIndex, subtable]
             );
+        case '62':
+            return contextParams => chainingSubstitutionFormat2.apply(
+                this, [contextParams, subtable]
+            );
         case '63':
             return contextParams => chainingSubstitutionFormat3.apply(
                 this, [contextParams, subtable]
@@ -501,6 +644,7 @@ FeatureQuery.prototype.lookupFeature = function (query) {
             }
 
             let substitution;
+            let subtableMatched = false;
             switch (substType) {
                 case '11':
                     substitution = lookup(contextParams.current);
@@ -518,6 +662,17 @@ FeatureQuery.prototype.lookupFeature = function (query) {
                         }));
                     }
                     break;
+                case '62': {
+                    const result = lookup(contextParams);
+                    subtableMatched = result.matched;
+                    substitution = result.substitutions;
+                    if (substitution.length) {
+                        substitutions.splice(currentIndex, 1, new SubstitutionAction({
+                            id: 62, tag: query.tag, substitution
+                        }));
+                    }
+                    break;
+                }
                 case '63':
                     substitution = lookup(contextParams);
                     if (Array.isArray(substitution) && substitution.length) {
@@ -555,6 +710,7 @@ FeatureQuery.prototype.lookupFeature = function (query) {
                     break;
             }
             contextParams = new ContextParams(substitutions, currentIndex);
+            if (subtableMatched) break;
             if (Array.isArray(substitution) && !substitution.length) continue;
             substitution = null;
         }

--- a/test/chainingSubstitutionFormat2.spec.mjs
+++ b/test/chainingSubstitutionFormat2.spec.mjs
@@ -1,0 +1,257 @@
+import assert from 'assert';
+import { Font, Glyph, Path } from '../src/opentype.mjs';
+import FeatureQuery from '../src/features/featureQuery.mjs';
+import { ContextParams } from '../src/tokenizer.mjs';
+
+/**
+ * Build a minimal font with a GSUB chaining context substitution format 2
+ * lookup and two nested single substitutions.
+ *
+ * The first chaining rule matches D A B C and deliberately does nothing.
+ * The second matches D A B at the end of the sequence and applies:
+ * B(2) -> B.alt1(5) -> B.alt2(6).
+ */
+function buildChainingSubst2Font() {
+    const glyphs = [
+        new Glyph({ name: '.notdef', advanceWidth: 500, path: new Path() }),
+        new Glyph({ name: 'A', unicode: 0x41, advanceWidth: 500, path: new Path() }),
+        new Glyph({ name: 'B', unicode: 0x42, advanceWidth: 500, path: new Path() }),
+        new Glyph({ name: 'C', unicode: 0x43, advanceWidth: 500, path: new Path() }),
+        new Glyph({ name: 'D', unicode: 0x44, advanceWidth: 500, path: new Path() }),
+        new Glyph({ name: 'B.alt1', advanceWidth: 500, path: new Path() }),
+        new Glyph({ name: 'B.alt2', advanceWidth: 500, path: new Path() }),
+    ];
+    const font = new Font({
+        familyName: 'ChainingSubst2Test',
+        styleName: 'Regular',
+        unitsPerEm: 1000,
+        ascender: 800,
+        descender: -200,
+        glyphs: glyphs,
+    });
+
+    font.tables.gsub = {
+        version: 1,
+        scripts: [{
+            tag: 'delf',
+            script: {
+                defaultLangSys: {
+                    reserved: 0,
+                    reqFeatureIndex: 0xffff,
+                    featureIndexes: [0],
+                },
+                langSysRecords: [],
+            },
+        }],
+        features: [{
+            tag: 'ccmp',
+            feature: { params: 0, lookupListIndexes: [2] },
+        }],
+        lookups: [{
+            lookupType: 1,
+            lookupFlag: 0,
+            subtables: [{
+                substFormat: 1,
+                coverage: { format: 1, glyphs: [2] },
+                deltaGlyphId: 3,
+            }],
+        }, {
+            lookupType: 1,
+            lookupFlag: 0,
+            subtables: [{
+                substFormat: 2,
+                coverage: { format: 1, glyphs: [5] },
+                substitute: [6],
+            }],
+        }, {
+            lookupType: 6,
+            lookupFlag: 0,
+            subtables: [{
+                substFormat: 2,
+                coverage: { format: 1, glyphs: [2] },
+                backtrackClassDef: {
+                    format: 2,
+                    ranges: [
+                        { start: 1, end: 1, classId: 1 },
+                        { start: 4, end: 4, classId: 2 },
+                    ],
+                },
+                inputClassDef: {
+                    format: 2,
+                    ranges: [{ start: 2, end: 2, classId: 1 }],
+                },
+                lookaheadClassDef: {
+                    format: 2,
+                    ranges: [{ start: 3, end: 3, classId: 1 }],
+                },
+                chainClassSet: [[], [{
+                    backtrack: [1, 2],
+                    input: [],
+                    lookahead: [1],
+                    lookupRecords: [],
+                }, {
+                    backtrack: [1, 2],
+                    input: [],
+                    lookahead: [],
+                    lookupRecords: [
+                        { sequenceIndex: 0, lookupListIndex: 0 },
+                        { sequenceIndex: 0, lookupListIndex: 1 },
+                    ],
+                }]],
+            }],
+        }],
+    };
+    return font;
+}
+
+function configureSecondInputRule(font, lookupRecords) {
+    const subtable = font.tables.gsub.lookups[2].subtables[0];
+    subtable.coverage = { format: 1, glyphs: [1] };
+    subtable.backtrackClassDef = { format: 2, ranges: [] };
+    subtable.inputClassDef = {
+        format: 2,
+        ranges: [
+            { start: 1, end: 1, classId: 1 },
+            { start: 2, end: 2, classId: 2 },
+        ],
+    };
+    subtable.lookaheadClassDef = { format: 2, ranges: [] };
+    subtable.chainClassSet = [[], [{
+        backtrack: [],
+        input: [2],
+        lookahead: [],
+        lookupRecords: lookupRecords,
+    }]];
+    return subtable;
+}
+
+describe('chainingSubstitutionFormat2', function () {
+    it('should honor backtrack, rule, and lookup record order', function () {
+        const font = buildChainingSubst2Font();
+
+        assert.deepEqual(font.stringToGlyphIndexes('DAB'), [4, 1, 6]);
+        assert.deepEqual(font.stringToGlyphIndexes('DABC'), [4, 1, 2, 3]);
+        assert.deepEqual(font.stringToGlyphIndexes('ADB'), [1, 4, 2]);
+    });
+
+    it('should preserve input positions for a later sequenceIndex', function () {
+        const font = buildChainingSubst2Font();
+        const query = new FeatureQuery(font);
+        const subtable = configureSecondInputRule(font, [
+            { sequenceIndex: 1, lookupListIndex: 0 },
+            { sequenceIndex: 1, lookupListIndex: 1 },
+        ]);
+
+        const lookup = query.getLookupMethod(
+            font.tables.gsub.lookups[2],
+            subtable
+        );
+        const result = lookup(new ContextParams([1, 2], 0));
+
+        assert.deepEqual(result, {
+            matched: true,
+            substitutions: [
+                { sequenceIndex: 1, substitution: 5 },
+                { sequenceIndex: 1, substitution: 6 },
+            ],
+        });
+        assert.deepEqual(font.stringToGlyphIndexes('AB'), [1, 6]);
+    });
+
+    it('should stop after the first matching nested subtable', function () {
+        const font = buildChainingSubst2Font();
+        const query = new FeatureQuery(font);
+        const subtable = configureSecondInputRule(font, [
+            { sequenceIndex: 1, lookupListIndex: 0 },
+        ]);
+        font.tables.gsub.lookups[0].subtables.push({
+            substFormat: 2,
+            coverage: { format: 1, glyphs: [2] },
+            substitute: [6],
+        });
+
+        const lookup = query.getLookupMethod(
+            font.tables.gsub.lookups[2],
+            subtable
+        );
+        const result = lookup(new ContextParams([1, 2], 0));
+
+        assert.deepEqual(result, {
+            matched: true,
+            substitutions: [
+                { sequenceIndex: 1, substitution: 5 },
+            ],
+        });
+    });
+
+    it('should resolve extension lookups wrapping single substitutions', function () {
+        const font = buildChainingSubst2Font();
+        const query = new FeatureQuery(font);
+        const subtable = configureSecondInputRule(font, [
+            { sequenceIndex: 1, lookupListIndex: 0 },
+        ]);
+        const extension = font.tables.gsub.lookups[0].subtables[0];
+        font.tables.gsub.lookups[0] = {
+            lookupType: 7,
+            lookupFlag: 0,
+            subtables: [{
+                substFormat: 1,
+                lookupType: 1,
+                extension: extension,
+            }],
+        };
+
+        const lookup = query.getLookupMethod(
+            font.tables.gsub.lookups[2],
+            subtable
+        );
+        const result = lookup(new ContextParams([1, 2], 0));
+
+        assert.deepEqual(result, {
+            matched: true,
+            substitutions: [
+                { sequenceIndex: 1, substitution: 5 },
+            ],
+        });
+    });
+
+    it('should reject unsupported nested substitution types', function () {
+        const font = buildChainingSubst2Font();
+        const query = new FeatureQuery(font);
+        const subtable = configureSecondInputRule(font, [
+            { sequenceIndex: 1, lookupListIndex: 0 },
+        ]);
+        font.tables.gsub.lookups[0] = {
+            lookupType: 4,
+            lookupFlag: 0,
+            subtables: [{ substFormat: 1 }],
+        };
+
+        const lookup = query.getLookupMethod(
+            font.tables.gsub.lookups[2],
+            subtable
+        );
+
+        assert.throws(
+            () => lookup(new ContextParams([1, 2], 0)),
+            /Substitution type 41 is not supported/
+        );
+    });
+
+    it('should stop after a matching no-op top-level subtable', function () {
+        const font = buildChainingSubst2Font();
+        const firstSubtable = font.tables.gsub.lookups[2].subtables[0];
+        const laterSubtable = JSON.parse(JSON.stringify(firstSubtable));
+        laterSubtable.chainClassSet[1] = [{
+            backtrack: [1, 2],
+            input: [],
+            lookahead: [1],
+            lookupRecords: [
+                { sequenceIndex: 0, lookupListIndex: 0 },
+            ],
+        }];
+        font.tables.gsub.lookups[2].subtables.push(laterSubtable);
+
+        assert.deepEqual(font.stringToGlyphIndexes('DABC'), [4, 1, 2, 3]);
+    });
+});


### PR DESCRIPTION
## Description

Adds execution support for the GSUB chaining contextual substitution format that
the parser already exposes as lookup type 6, format 2.

The implementation:

- gates rules through coverage and the input class set;
- matches backtrack classes in reverse logical order, then input and lookahead
  classes through their separate class definitions;
- applies nested lookup records in design order, with later records consuming
  earlier substitutions;
- retains each `sequenceIndex`, so only the targeted token is changed;
- stops at the first matching rule and subtable, including deliberate no-op
  rules;
- supports nested single substitutions (formats 1 and 2), including type 7
  extension wrappers.

The nested-lookup scope is intentionally limited to single substitutions. Other
nested lookup types fail explicitly rather than being silently skipped. Lookup
flag filtering remains a broader shaping-engine follow-up; both real-world
reproducers below use lookup flag 0 and nested type 1.

## Motivation and Context

On current `master`, the presence of a type 6 / format 2 subtable causes
`getPath()` and `getAdvanceWidth()` to throw before coverage is even evaluated:

```text
substitutionType : 62 lookupType: 6 - substFormat: 2 is not yet supported
```

This reproduces with both SF Hebrew Rounded and the current Google Fonts Roboto
variable font.

This is a focused extraction of the GSUB 6/2 portion of #816, following the
review suggestion there to split the GSUB work from unrelated variation
changes. Thanks to @wiltse439 for the original implementation work; the commit
also credits them as a co-author. This PR leaves the existing type 6 / format 3
path untouched, preserving the `sequenceIndex` fix from #824.

## How Has This Been Tested?

- `npm test`: 348 passing, including build, minified distributions, and source
  lint.
- Six synthetic regressions cover reverse backtrack order, first-match no-op
  rules, ordered records, nonzero `sequenceIndex` through token application,
  first matching nested and top-level subtables, extension wrappers, and
  explicit unsupported-type errors.
- SF Hebrew Rounded:
  - an end-of-run mark changes from glyph 110 to final-form glyph 163;
  - the same mark followed by a protected lookahead remains glyph 110;
  - the previous unrelated Latin probe renders without throwing.
- Google Fonts Roboto variable font:
  - `i` + combining acute shapes to glyphs `[636, 169]`;
  - `affinity` renders without throwing.
- Both generated ESM and CommonJS distributions produce the same real-font
  results.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **Contribute** README section.
