### PR TITLE
fix(path): keep a legitimate final lineTo the optimizer drops at small sizes

### DIFF
--- a/src/path.mjs
+++ b/src/path.mjs
@@ -62,7 +62,14 @@ function optimizeCommands(commands) {
             startX = cmd.x;
             startY = cmd.y;
         } else if (cmd.type === 'L' && (!nextCommand || nextCommand.type === 'Z')) {
-            if(!(Math.abs(cmd.x - startX) > 1 || Math.abs(cmd.y - startY) > 1)) {
+            // This existing optimization removes a final lineTo that returns to
+            // the subpath start. The old test used an absolute 1-unit window, so
+            // at small font sizes -- where the whole glyph scales down -- a
+            // legitimate final segment ending within 1 unit of the start was
+            // dropped too, closing the outline with the wrong diagonal (issue
+            // #804). Require an exact return to the start instead, the same test
+            // the other redundancy checks in this function already use.
+            if (cmd.x === startX && cmd.y === startY) {
                 subpath.pop();
             }
         } else if (cmd.type === 'L' && previousCommand && previousCommand.x === cmd.x && previousCommand.y === cmd.y) {

--- a/test/path.spec.mjs
+++ b/test/path.spec.mjs
@@ -112,6 +112,21 @@ describe('path.mjs', function() {
         assert.equal(result, 'M100 200L300 200L300 400Z');
     });
 
+    it('should keep a final lineTo that lands near but not exactly on the start (#804)', function() {
+        // A legitimate final segment whose endpoint is within 1 absolute unit
+        // of the start -- which happens at small font sizes, where the whole
+        // glyph is scaled down -- must not be dropped. Pre-fix the
+        // `Math.abs(...) > 1` window removed it, closing the outline with the
+        // wrong diagonal Z instead of the real line (issue #804).
+        const path = new Path();
+        path.moveTo(0, 0);
+        path.lineTo(10, 30);
+        path.lineTo(0.4, 0.3); // near the start, but a real, distinct vertex
+        path.close();
+        const result = path.toPathData({optimize: true, flipY: false});
+        assert.equal(result, 'M0 0L10 30L0.40 0.30Z');
+    });
+
     it('should optimize SVG paths if path closing point matches starting point', function() {
         const optimizedResult = 'M0 50L0 250L50 250L100 250L150 250L200 250L200 50ZM250 50L250 250L300 250L350 250L400 250L450 250L450 50Z';
         assert.equal(testPath2.toPathData({flipY: false}), optimizedResult);


### PR DESCRIPTION
## Description

`optimizeCommands` in `src/path.mjs` drops a final `lineTo` before a close when its endpoint sits within an absolute 1-unit window of the subpath start:

```js
if (!(Math.abs(cmd.x - startX) > 1 || Math.abs(cmd.y - startY) > 1)) {
    subpath.pop();
}
```

That window is in the scaled coordinate space, so at small font sizes the whole glyph shrinks into 1 unit and a real final segment is removed. The outline then closes straight from the previous point back to the start, which is the wrong diagonal. Every other redundancy check in the same function already compares exact coordinates; this branch was the odd one out.

The fix requires an exact return to the subpath start:

```js
if (cmd.x === startX && cmd.y === startY) {
    subpath.pop();
}
```

The new drop set (`dx === 0 && dy === 0`) is a strict subset of the old within-1-unit set, so it can only stop the old wrong removals and never drops a command the old code kept.

I deliberately left the existing no-`Z` behavior alone: an unclosed path whose final `lineTo` lands exactly on the start is still dropped, which the `PaintType and StrokeWidth` CFF test depends on. Whether an unclosed stroked contour should keep that segment is a separate question, out of scope here.

## Motivation and Context

Fixes #804. A Bodoni "S" renders correctly at size 72 but loses its final command at size 53 and closes with a diagonal instead of a vertical; smaller sizes get worse. @herrstrietzel already narrowed it to the v2 post-optimization dropping commands at small sizes, and `optimize: false` works around it. This pins the cause to the 1-unit window and keeps optimization on.

## How Has This Been Tested?

- Added a regression test in `test/path.spec.mjs`: a near-start final `lineTo` before a close is kept. It fails on current master (`M0 0L10 30Z`) and passes with the fix (`M0 0L10 30L0.40 0.30Z`).
- `npx mocha "test/**/*.spec.mjs"`: 343 passing, 0 failing.
- `eslint src`: clean.
- `npm run build` and `npm run dist`: both succeed. The only local failure is a pre-existing Windows-only path bug in the `generate-recursive-cff-font.mjs` helper (it builds a `C:\C:\...` path), unrelated to this change and green on the Linux CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I ran the test suite: build, dist, the mocha spec suite (343 passing) and `eslint src` all pass. See the note above about the unrelated Windows-only helper.
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **Contribute** README section.
