### PR TITLE
fix: GDEF MarkGlyphSets offset parsing

### DIFF
--- a/src/tables/gdef.mjs
+++ b/src/tables/gdef.mjs
@@ -38,7 +38,7 @@ var ligCaretList = function() {
 
 var markGlyphSets = function() {
     this.parseUShort(); // Version
-    return this.parseList(Parser.pointer(Parser.coverage));
+    return this.parseList(Parser.pointer32(Parser.coverage));
 };
 
 function parseGDEFTable(data, start) {

--- a/test/tables/gdef.spec.mjs
+++ b/test/tables/gdef.spec.mjs
@@ -19,10 +19,9 @@ describe('tables/gdef.mjs', function() {
         ' 00 08 00 0c 00 10 00 01 04 80 00 01 09 00 00 01' +
         ' 0d 80 00 02 00 05 00 2b 00 2b 00 01 00 2e 00 2e' +
         ' 00 02 00 4a 00 4a 00 04 00 65 00 65 00 01 00 7e' +
-        ' 00 7e 00 02 00 01 00 05 00 00 00 18 00 00 00 1e' +
-        ' 00 00 00 24 00 00 00 2a 00 00 00 30 00 01 00 01' +
-        ' 00 0a 00 01 00 01 00 0b 00 01 00 01 00 0c 00 01' +
-        ' 00 01 00 0d 00 01 00 01 00 0e';
+        ' 00 7e 00 02 00 01 00 02 00 00 00 0c 00 00 00 16' +
+        ' 00 01 00 03 00 05 00 06 00 07 00 02 00 02 00 0a' +
+        ' 00 0c 00 00 00 14 00 14 00 03';
 
     const table = {
         version: 1.2,
@@ -76,11 +75,14 @@ describe('tables/gdef.mjs', function() {
             ]
         },
         markGlyphSets: [
-            { format: 1, glyphs: [10] },
-            { format: 1, glyphs: [11] },
-            { format: 1, glyphs: [12] },
-            { format: 1, glyphs: [13] },
-            { format: 1, glyphs: [14] }
+            { format: 1, glyphs: [5, 6, 7] },
+            {
+                format: 2,
+                ranges: [
+                    { start: 10, end: 12, index: 0 },
+                    { start: 20, end: 20, index: 3 }
+                ]
+            }
         ]
     };
 

--- a/test/tables/gdef.spec.mjs
+++ b/test/tables/gdef.spec.mjs
@@ -4,25 +4,28 @@ import gdef from '../../src/tables/gdef.mjs';
 
 describe('tables/gdef.mjs', function() {
     const data =
-        ' 00 01 00 00 00 0c 00 40 00 78 00 d0 00 02 00 08' +
-        ' 00 65 00 65 00 03 00 f2 00 f2 00 01 02 08 02 08' +
-        ' 00 01 02 0a 02 0a 00 01 02 1b 02 1b 00 01 02 22' +
-        ' 02 22 00 01 03 f3 03 f4 00 02 04 14 04 14 00 03' +
-        ' 00 0e 00 05 00 18 00 30 00 20 00 28 00 30 00 02' +
-        ' 00 01 00 0f 00 13 00 00 00 03 00 0b 00 0d 00 0e' +
-        ' 00 03 00 27 00 28 00 29 00 03 00 04 00 0d 00 0e' +
-        ' 00 03 00 18 00 19 00 1a 00 0e 00 05 00 1c 00 24' +
-        ' 00 32 00 36 00 44 00 01 00 05 03 ec 03 ed 03 ef' +
-        ' 03 f0 03 f1 00 01 00 04 00 01 08 43 00 02 00 06' +
-        ' 00 0a 00 01 05 82 00 01 0b 04 00 01 00 1e 00 02' +
-        ' 00 06 00 0a 00 01 06 00 00 01 0c 00 00 03 00 08' +
-        ' 00 0c 00 10 00 01 04 80 00 01 09 00 00 01 0d 80' +
-        ' 00 02 00 05 00 2b 00 2b 00 01 00 2e 00 2e 00 02' +
-        ' 00 4a 00 4a 00 04 00 65 00 65 00 01 00 7e 00 7e' +
-        ' 00 02';
+        ' 00 01 00 02 00 0e 00 42 00 7a 00 d2 00 f4 00 02' +
+        ' 00 08 00 65 00 65 00 03 00 f2 00 f2 00 01 02 08' +
+        ' 02 08 00 01 02 0a 02 0a 00 01 02 1b 02 1b 00 01' +
+        ' 02 22 02 22 00 01 03 f3 03 f4 00 02 04 14 04 14' +
+        ' 00 03 00 0e 00 05 00 18 00 30 00 20 00 28 00 30' +
+        ' 00 02 00 01 00 0f 00 13 00 00 00 03 00 0b 00 0d' +
+        ' 00 0e 00 03 00 27 00 28 00 29 00 03 00 04 00 0d' +
+        ' 00 0e 00 03 00 18 00 19 00 1a 00 0e 00 05 00 1c' +
+        ' 00 24 00 32 00 36 00 44 00 01 00 05 03 ec 03 ed' +
+        ' 03 ef 03 f0 03 f1 00 01 00 04 00 01 08 43 00 02' +
+        ' 00 06 00 0a 00 01 05 82 00 01 0b 04 00 01 00 1e' +
+        ' 00 02 00 06 00 0a 00 01 06 00 00 01 0c 00 00 03' +
+        ' 00 08 00 0c 00 10 00 01 04 80 00 01 09 00 00 01' +
+        ' 0d 80 00 02 00 05 00 2b 00 2b 00 01 00 2e 00 2e' +
+        ' 00 02 00 4a 00 4a 00 04 00 65 00 65 00 01 00 7e' +
+        ' 00 7e 00 02 00 01 00 05 00 00 00 18 00 00 00 1e' +
+        ' 00 00 00 24 00 00 00 2a 00 00 00 30 00 01 00 01' +
+        ' 00 0a 00 01 00 01 00 0b 00 01 00 01 00 0c 00 01' +
+        ' 00 01 00 0d 00 01 00 01 00 0e';
 
     const table = {
-        version: 1,
+        version: 1.2,
         attachList: {
             attachPoints: [
                 [11, 13, 14],
@@ -34,7 +37,7 @@ describe('tables/gdef.mjs', function() {
             coverage: {
                 format: 2,
                 ranges: [
-                  { end: 19, index: 0, start: 15 }
+                    { end: 19, index: 0, start: 15 }
                 ]
             }
         },
@@ -55,23 +58,30 @@ describe('tables/gdef.mjs', function() {
         ligCaretList: {
             coverage: {format: 1, glyphs: [1004, 1005, 1007, 1008, 1009]},
             ligGlyphs: [
-                  [{coordinate: 2115}],
-                  [{coordinate: 1410}, {coordinate: 2820}],
-                  [{coordinate: 2304}],
-                  [{coordinate: 1536}, {coordinate: 3072}],
-                  [{coordinate: 1152}, {coordinate: 2304}, {coordinate: 3456}]
+                [{coordinate: 2115}],
+                [{coordinate: 1410}, {coordinate: 2820}],
+                [{coordinate: 2304}],
+                [{coordinate: 1536}, {coordinate: 3072}],
+                [{coordinate: 1152}, {coordinate: 2304}, {coordinate: 3456}]
             ]
         },
         markAttachClassDef: {
             format: 2,
             ranges: [
-              {classId: 1, start: 43, end: 43},
-              {classId: 2, start: 46, end: 46},
-              {classId: 4, start: 74, end: 74},
-              {classId: 1, start: 101, end: 101},
-              {classId: 2, start: 126, end: 126}
-           ]
+                {classId: 1, start: 43, end: 43},
+                {classId: 2, start: 46, end: 46},
+                {classId: 4, start: 74, end: 74},
+                {classId: 1, start: 101, end: 101},
+                {classId: 2, start: 126, end: 126}
+            ]
         },
+        markGlyphSets: [
+            { format: 1, glyphs: [10] },
+            { format: 1, glyphs: [11] },
+            { format: 1, glyphs: [12] },
+            { format: 1, glyphs: [13] },
+            { format: 1, glyphs: [14] }
+        ]
     };
 
     it('can parse a GDEF table', function() {


### PR DESCRIPTION
Fix GDEF MarkGlyphSets parsing to read coverage offsets as Offset32 instead of Offset16.

## Description

The GDEF MarkGlyphSets table stores its coverage offsets as 32-bit offsets. The parser was using 16-bit pointers, which caused mark glyph set coverage data to be parsed from the wrong positions.
https://learn.microsoft.com/ja-jp/typography/opentype/spec/gdef#mark-glyph-sets-table

## Motivation and Context
This fixes incorrect parsing of GDEF MarkGlyphSets for fonts that rely on mark filtering sets, such as lookups using `markFilteringSet: 4`.

## How Has This Been Tested?
Ran:

- `npx mocha test/tables/gdef.spec.mjs`
- `npx eslint src/tables/gdef.mjs`
- `git diff --check`

The existing GDEF fixture was extended to version 1.2 with MarkGlyphSets coverage data, so the existing GDEF parse test now covers Offset32 MarkGlyphSets parsing.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **Contribute** README section.