### PR TITLE
fix(font): load all glyphs before writing when parsed in lowMemory mode

### DIFF
--- a/src/font.mjs
+++ b/src/font.mjs
@@ -600,6 +600,13 @@ Font.prototype.validate = function() {
  * @return {opentype.Table}
  */
 Font.prototype.toTables = function() {
+    // In lowMemory mode, glyphs are only materialized in `this.glyphs` on
+    // first access, so `this.glyphs.length` only counts glyphs touched so
+    // far. Touch every glyph before writing, or the output font silently
+    // drops whichever ones were never requested.
+    for (let i = 0; i < this.numGlyphs; i += 1) {
+        this.glyphs.get(i);
+    }
     return sfnt.fontToTable(this);
 };
 /**

--- a/test/font.spec.mjs
+++ b/test/font.spec.mjs
@@ -180,6 +180,15 @@ describe('font.mjs', function() {
             assert.ok(tables);
             assert.equal(tables.tableName, 'sfnt');
         });
+
+        it('includes every glyph when the font was parsed in lowMemory mode', function() {
+            const lowMemFont = loadSync('./test/fonts/Roboto-Black.ttf', {lowMemory: true});
+            assert.equal(lowMemFont.numGlyphs, 1294);
+            assert.equal(lowMemFont.glyphs.length, 0); // nothing accessed yet
+
+            const roundTripped = parse(lowMemFont.toArrayBuffer());
+            assert.equal(roundTripped.glyphs.length, 1294);
+        });
     });
 });
 


### PR DESCRIPTION
## Description

`GlyphSet` (`src/glyphset.mjs`) only builds a glyph the first time something asks for it in lowMemory mode. Right after parsing, `font.glyphs.length` is 0. It only grows as code touches individual glyphs.

`Font.prototype.toTables()` (`src/font.mjs`) used `font.glyphs.length` as the glyph count when handing the font to `sfnt.fontToTable()` for writing:

```js
Font.prototype.toTables = function() {
    return sfnt.fontToTable(this);
};
```

So `toArrayBuffer()` wrote out only the glyphs that had already been touched by something else (name generation, cmap building, etc.), and silently dropped the rest.

## Motivation and Context

Fixes #742. I reproduced it with `test/fonts/Roboto-Black.ttf` (1294 glyphs): parse with `{ lowMemory: true }`, call `toArrayBuffer()` right away, and the output font has 93 glyphs. No error, no warning.

The fix loads every glyph, up to `font.numGlyphs` (the real count from the `maxp` table), before writing:

```js
Font.prototype.toTables = function() {
    for (let i = 0; i < this.numGlyphs; i += 1) {
        this.glyphs.get(i);
    }
    return sfnt.fontToTable(this);
};
```

Each glyph loads through the existing `GlyphSet.get()` method, so this needs no new loading logic. Reading a font in lowMemory mode still behaves the same as before: `glyphs.length` still starts at 0 and grows only as code touches glyphs. This change only affects writing.

## How Has This Been Tested?

Added a test in `test/font.spec.mjs`: parse a font in lowMemory mode, confirm `glyphs.length` is 0 before touching anything, then round-trip it through `toArrayBuffer()` and `parse()` and check all 1294 glyphs come back.

- Before the fix: 93 glyphs come back.
- After the fix: 1294 glyphs come back.

`npx mocha --recursive`: 343 passing, 0 failing.
`eslint src`: clean.
`npm run build` and `npm run dist`: both succeed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the README accordingly.
- [x] I have read the Contribute README section.
