### PR TITLE
fix(glyph): missing close path commands

### DIFF
--- a/src/glyph.mjs
+++ b/src/glyph.mjs
@@ -232,7 +232,7 @@ Glyph.prototype.getPath = function(x, y, fontSize, options, font) {
             p.curveTo(x + (cmd.x1 * xScale), y + (-cmd.y1 * yScale),
                 x + (cmd.x2 * xScale), y + (-cmd.y2 * yScale),
                 x + (cmd.x * xScale), y + (-cmd.y * yScale));
-        } else if (cmd.type === 'Z' && p.stroke && p.strokeWidth) {
+        } else if (cmd.type === 'Z') {
             p.closePath();
         }
     }

--- a/test/glyph.spec.mjs
+++ b/test/glyph.spec.mjs
@@ -161,6 +161,17 @@ describe('glyph.mjs', function() {
         });
     });
 
+    describe('path data', function() {
+        it('should keep close path commands that separate independent shapes', function() {
+            // The path close commands are needed between independent shape parts
+            // in order to correctly render the stroke-linecap. See issue #799.
+            const font = loadSync('./test/fonts/FiraSansMedium.woff');
+            const glyph = font.getPaths('g', 0, 0, 16)[0];
+            const path_data = glyph.toPathData({decimalPlaces: 1, optimize: false, flipY: false});
+            assert.notEqual(path_data.indexOf('C2.7-2.5 2.9-2.8 3.1-2.9ZM2.4-5.7'), -1);
+        });
+    });
+
     describe('component transformation', function() {
         // @TODO test components more thoroughly,
         // maybe move to a separate glyf test file


### PR DESCRIPTION
Fixes #799 

This is a partial revert of commit 946f255 that removed the path close commands from Glpyh.getPath.

## Description
In 2.0.0 / 946f255, close path commands were removed in `Glpyh.getPath` if a stroke was not defined on the path.

https://github.com/opentypejs/opentype.js/blob/5d65b6dcfab5115f90d375f8ba6b7942fdaa0138/src/glyph.mjs#L235

Removing the close path commands can cause issues with `stroke-linecap` when a character consists of multiple independent shapes, such as the letter `d`. In this case, one shape defines the outer outline, while another defines the inner hole. Because the close path command is omitted, the outer path is never closed before moving to the inner path. As a result, one corner of the character is rendered without the expected stroke cap. See issue #799 for an example SVG.

This issue affects `Font.getPaths`, which returns path data for a string of text. Currently, GlyphRenderOptions does not provide a way to specify whether the text will be stroked, so the generated glyph data always omits the close path commands. This creates a problem for anyone who simply want to convert text into path data, as the resulting paths are not valid for all use cases.

## Motivation and Context
Issue #799 

## How Has This Been Tested?
All unit tests pass and visually looks correct.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **Contribute** README section.
