### PR TITLE
fix(font): fall back per name record across name table platforms

### DIFF
--- a/src/font.mjs
+++ b/src/font.mjs
@@ -538,13 +538,21 @@ Font.prototype.drawMetrics = function(ctx, text, x, y, fontSize, options) {
 };
 
 /**
- * @param  {string}
- * @return {string}
+ * Look up the English string for a name record, falling back through the
+ * name table platforms (unicode, macintosh, windows) per property.
+ * Fonts are not required to store every standard name record on every
+ * platform: some only carry them on the Windows platform, while their
+ * Macintosh table holds nothing but custom (ID >= 256) names.
+ * @param  {string} name
+ * @return {string|undefined}
  */
 Font.prototype.getEnglishName = function(name) {
-    const translations = (this.names.unicode || this.names.macintosh || this.names.windows)[name];
-    if (translations) {
-        return translations.en;
+    const platforms = [this.names.unicode, this.names.macintosh, this.names.windows];
+    for (let i = 0; i < platforms.length; i++) {
+        const translations = platforms[i] && platforms[i][name];
+        if (translations && translations.en !== undefined) {
+            return translations.en;
+        }
     }
 };
 

--- a/test/font.spec.mjs
+++ b/test/font.spec.mjs
@@ -174,6 +174,55 @@ describe('font.mjs', function() {
         });
     });
 
+    describe('getEnglishName', function() {
+        // Some fonts only store the standard name records (IDs 0-17) on a single
+        // platform, while another platform table holds custom (ID >= 256) names.
+        // Looking names up on one platform table only makes those fonts report
+        // undefined for every standard name. See issue #570.
+        function windowsOnlyNames() {
+            return {
+                unicode: {},
+                macintosh: { 256: { en: 'Straight-sided six and nine' } },
+                windows: {
+                    fontFamily: { en: 'MyFont' },
+                    fontSubfamily: { en: 'Medium' }
+                }
+            };
+        }
+
+        it('returns the English string of the first platform that has the record', function() {
+            font.names.unicode.fontFamily = { en: 'Unicode name' };
+            font.names.macintosh.fontFamily = { en: 'Macintosh name' };
+            font.names.windows.fontFamily = { en: 'Windows name' };
+            assert.equal(font.getEnglishName('fontFamily'), 'Unicode name');
+        });
+
+        it('falls back per record to a platform that has it', function() {
+            font.names = windowsOnlyNames();
+            assert.equal(font.getEnglishName('fontFamily'), 'MyFont');
+            assert.equal(font.getEnglishName('fontSubfamily'), 'Medium');
+        });
+
+        it('skips platforms that have the record without an English translation', function() {
+            font.names.unicode.fontFamily = { de: 'Deutscher Name' };
+            font.names.macintosh.fontFamily = { en: 'Macintosh name' };
+            assert.equal(font.getEnglishName('fontFamily'), 'Macintosh name');
+        });
+
+        it('returns undefined when no platform has the record', function() {
+            font.names = windowsOnlyNames();
+            assert.equal(font.getEnglishName('designer'), undefined);
+        });
+
+        it('lets a font with names on one platform only be written out', function() {
+            font.names = windowsOnlyNames();
+            const parsed = parse(font.toArrayBuffer());
+            assert.equal(parsed.getEnglishName('fontFamily'), 'MyFont');
+            assert.equal(parsed.getEnglishName('fontSubfamily'), 'Medium');
+            assert.equal(parsed.getEnglishName('postScriptName'), 'MyFont-Medium');
+        });
+    });
+
     describe('toTables', function() {
         it('returns an sfnt font table', function() {
             const tables = font.toTables();


### PR DESCRIPTION
## Description

`Font.prototype.getEnglishName()` selected a single platform object wholesale and read every name record from it:

```js
const translations = (this.names.unicode || this.names.macintosh || this.names.windows)[name];
```

Since the first truthy platform table wins, a font whose Macintosh table holds only custom names (ID >= 256) never falls back to the Windows table, where its standard records (ID 0-17) actually live. Every standard name then comes back `undefined`.

This changes the lookup to walk the platforms per record, and to skip a platform that carries the record without an English translation.

## Motivation and Context

Fixes #570.

A real-world example is [Pretendard](https://github.com/orioncactus/pretendard) (OFL, widely used for Korean text). `Pretendard-Medium.otf` parses like this:

```
names.macintosh : 256 … 281                    (custom names only)
names.windows   : 256 … 281, copyright, fontFamily, fontSubfamily,
                  uniqueID, fullName, version, postScriptName, …,
                  preferredFamily, preferredSubfamily
```

Before:

```
font.getEnglishName('fontFamily')         → undefined
font.getEnglishName('fontSubfamily')      → undefined
font.getEnglishName('preferredSubfamily') → undefined
```

After:

```
font.getEnglishName('fontFamily')         → 'Pretendard Medium'
font.getEnglishName('fontSubfamily')      → 'Regular'
font.getEnglishName('preferredSubfamily') → 'Medium'
```

The same lookup is used when writing a font out. `fontToSfntTable()` derives the PostScript name from it:

```js
postScriptName = englishFamilyName.replace(/\s/g, '') + '-' + englishStyleName;
```

so `font.toArrayBuffer()` / `font.download()` threw `TypeError: Cannot read properties of undefined (reading 'replace')` for these fonts — the download failure described in #570.

Downstream this surfaces in applications that read font metadata through opentype.js; e.g. Penpot's custom font upload crashes on such files ([penpot#10436](https://github.com/penpot/penpot/issues/10436)).

## How Has This Been Tested?

- `npm run test` on Node 26: 347 passing, eslint clean.
- 5 new tests in `test/font.spec.mjs` under `getEnglishName`. Reverting `src/font.mjs` alone makes 3 of them fail, including the write-out case, which fails at `sfnt.mjs` with the `replace` TypeError above.
- Manually verified against `Pretendard-Medium.otf` (values quoted above).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Behaviour only changes where the old code returned `undefined`; a record found on the first platform is still returned from there.

## Checklist:

- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **Contribute** README section.
